### PR TITLE
Add optional namespace configuration

### DIFF
--- a/bindgen/src/gen_cs/mod.rs
+++ b/bindgen/src/gen_cs/mod.rs
@@ -35,6 +35,8 @@ pub struct Config {
     custom_types: HashMap<String, CustomTypeConfig>,
     #[serde(default)]
     external_packages: HashMap<String, String>,
+    #[serde(default)]
+    namespace: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -70,6 +72,7 @@ impl From<&ComponentInterface> for Config {
             cdylib_name: Some(format!("uniffi_{}", ci.namespace())),
             custom_types: HashMap::new(),
             external_packages: HashMap::new(),
+            namespace: Some(ci.namespace().to_string()),
         }
     }
 }
@@ -81,6 +84,7 @@ impl MergeWith for Config {
             cdylib_name: self.cdylib_name.merge_with(&other.cdylib_name),
             custom_types: self.custom_types.merge_with(&other.custom_types),
             external_packages: self.external_packages.merge_with(&other.external_packages),
+            namespace: self.namespace.merge_with(&other.namespace),
         }
     }
 }
@@ -256,7 +260,7 @@ impl CsCodeOracle {
 
             Type::Unresolved { name } => {
                 unreachable!("Type `{name}` must be resolved before calling create_code_type")
-            },
+            }
         }
     }
 }

--- a/bindgen/templates/wrapper.cs
+++ b/bindgen/templates/wrapper.cs
@@ -22,7 +22,12 @@ using System;
 using {{ imported_class }};
 {%- endfor %}
 
+{%- match config.namespace %}
+{%- when Some(namespace) %}
+namespace {{ namespace }};
+{%- else %}
 namespace {{ config.package_name() }}.{{ ci.namespace() }};
+{%- endmatch %}
 
 {%- for alias in self.type_aliases() %}
 using {{ alias.alias }} = {{ alias.original_type }};


### PR DESCRIPTION
Thanks for the great work!
We are using it successfully in Breez and it works very well. Only thing that we need is the ability to customize the namespace.
The reason is because we are using the same udl file for multiple languages and most languages use lower case for namespace/modules declarations so we can't make the namespace in the udl file suitable for c# case.
Therefore I added an optional configuration property to override the logic that composes the namespace today.
