### PR TITLE
Add docstring (reland)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +195,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -251,6 +271,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +303,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -465,6 +499,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +630,17 @@ name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -666,6 +734,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +751,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "uniffi"
@@ -690,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-cs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -702,6 +786,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
+ "textwrap 0.16.0",
  "toml",
  "uniffi_bindgen",
 ]
@@ -720,6 +805,7 @@ dependencies = [
  "uniffi-example-todolist",
  "uniffi-fixture-callbacks",
  "uniffi-fixture-coverall",
+ "uniffi-fixture-docstring",
  "uniffi-fixture-external-types",
  "uniffi-fixture-time",
 ]
@@ -809,6 +895,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-docstring"
+version = "0.22.0"
+dependencies = [
+ "glob",
+ "thiserror",
+ "uniffi",
+ "uniffi_bindgen",
+ "uniffi_testing",
+]
+
+[[package]]
 name = "uniffi-fixture-external-types"
 version = "0.22.0"
 dependencies = [
@@ -844,6 +941,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
+ "textwrap 0.16.0",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -937,6 +1035,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "weedle2"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -14,13 +14,14 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
+camino = "1.0.8"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
 extend = "1.1"
-heck = "0.4"
-uniffi_bindgen = { path = "../3rd-party/uniffi-rs/uniffi_bindgen" }
-serde = "1"
-toml = "0.5"
-camino = "1.0.8"
 fs-err = "2.7.0"
+heck = "0.4"
 paste = "1.0"
+serde = "1"
 serde_json = "1.0.0"
+textwrap = "0.16"
+toml = "0.5"
+uniffi_bindgen = { path = "../3rd-party/uniffi-rs/uniffi_bindgen" }

--- a/bindgen/src/gen_cs/mod.rs
+++ b/bindgen/src/gen_cs/mod.rs
@@ -416,4 +416,13 @@ pub mod filters {
     pub fn exception_name(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().error_name(nm))
     }
+
+    /// Get the idiomatic C# rendering of docstring
+    pub fn docstring(docstring: &str, spaces: &i32) -> Result<String, askama::Error> {
+        let middle = textwrap::indent(&textwrap::dedent(docstring), "/// ");
+        let wrapped = format!("/// <summary>\n{middle}\n/// </summary>");
+
+        let spaces = usize::try_from(*spaces).unwrap_or_default();
+        Ok(textwrap::indent(&wrapped, &" ".repeat(spaces)))
+    }
 }

--- a/bindgen/templates/CallbackInterfaceTemplate.cs
+++ b/bindgen/templates/CallbackInterfaceTemplate.cs
@@ -8,9 +8,10 @@
 
 {% if self.include_once_check("CallbackInterfaceRuntime.cs") %}{% include "CallbackInterfaceRuntime.cs" %}{% endif %}
 
-// Declaration and FfiConverters for {{ type_name }} Callback Interface
+{%- call cs::docstring(cbi, 0) %}
 public interface {{ type_name }} {
     {%- for meth in cbi.methods() %}
+    {%- call cs::docstring(meth, 4) %}
     {%- call cs::method_throws_annotation(meth.throws_type()) %}
     {%- match meth.return_type() %}
     {%- when Some with (return_type) %}

--- a/bindgen/templates/EnumTemplate.cs
+++ b/bindgen/templates/EnumTemplate.cs
@@ -10,8 +10,10 @@
 
 {%- if e.is_flat() %}
 
+{%- call cs::docstring(e, 0) %}
 public enum {{ type_name }}: int {
     {% for variant in e.variants() -%}
+    {%- call cs::docstring(variant, 4) %}
     {{ variant.name()|enum_variant }}{% if !loop.last %},{% endif %}
     {%- endfor %}
 }
@@ -39,8 +41,10 @@ class {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
 
 {% else %}
 
+{%- call cs::docstring(e, 0) %}
 public record {{ type_name }}{% if contains_object_references %}: IDisposable {% endif %} {
     {% for variant in e.variants() -%}
+    {%- call cs::docstring(variant, 4) %}
     {% if !variant.has_fields() -%}
     public record {{ variant.name()|class_name }}: {{ type_name }} {}
     {% else -%}

--- a/bindgen/templates/ErrorTemplate.cs
+++ b/bindgen/templates/ErrorTemplate.cs
@@ -5,12 +5,14 @@
 {%- let e = ci.get_error_definition(name).unwrap() %}
 
 {% if e.is_flat() %}
+{%- call cs::docstring(e, 0) %}
 public class {{ type_name }}: UniffiException {
     {{ type_name }}(string message): base(message) {}
 
     // Each variant is a nested class
     // Flat enums carries a string error message, so no special implementation is necessary.
     {% for variant in e.variants() -%}
+    {%- call cs::docstring(variant, 4) %}
     public class {{ variant.name()|exception_name }}: {{ type_name }} {
         public {{ variant.name()|exception_name }}(string message): base(message) {}
     }
@@ -50,9 +52,11 @@ class {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>, Call
 }
 
 {%- else %}
+{%- call cs::docstring(e, 0) %}
 public class {{ type_name }}: UniffiException{% if contains_object_references %}, IDisposable {% endif %} {
     // Each variant is a nested class
     {% for variant in e.variants() -%}
+    {%- call cs::docstring(variant, 4) %}
     {% if !variant.has_fields() -%}
     public class {{ variant.name()|exception_name }} : {{ type_name }} {}
     {% else %}

--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -6,9 +6,11 @@
 {%- let safe_handle_type = format!("{}SafeHandle", type_name) %}
 {%- if self.include_once_check("ObjectRuntime.cs") %}{% include "ObjectRuntime.cs" %}{% endif %}
 
+{%- call cs::docstring(obj, 0) %}
 public interface I{{ type_name }} {
     {% for meth in obj.methods() -%}
-    {% call cs::method_throws_annotation(meth.throws_type()) %}
+    {%- call cs::docstring(meth, 4) %}
+    {%- call cs::method_throws_annotation(meth.throws_type()) %}
     {% match meth.return_type() -%} {%- when Some with (return_type) -%} {{ return_type|type_name }} {%- when None %}void{%- endmatch %} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %});
     {% endfor %}
 }
@@ -26,18 +28,21 @@ public class {{ safe_handle_type }}: FFISafeHandle {
     }
 }
 
+{%- call cs::docstring(obj, 0) %}
 public class {{ type_name }}: FFIObject<{{ safe_handle_type }}>, I{{ type_name }} {
     public {{ type_name }}({{ safe_handle_type }} pointer): base(pointer) {}
 
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}
+    {%- call cs::docstring(cons, 4) %}
     public {{ type_name }}({% call cs::arg_list_decl(cons) -%}) :
         this({% call cs::to_ffi_call(cons) %}) {}
     {%- when None %}
     {%- endmatch %}
 
     {% for meth in obj.methods() -%}
-    {% call cs::method_throws_annotation(meth.throws_type()) %}
+    {%- call cs::docstring(meth, 4) %}
+    {%- call cs::method_throws_annotation(meth.throws_type()) %}
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) %}
@@ -54,6 +59,8 @@ public class {{ type_name }}: FFIObject<{{ safe_handle_type }}>, I{{ type_name }
 
     {% if !obj.alternate_constructors().is_empty() -%}
     {% for cons in obj.alternate_constructors() -%}
+    {%- call cs::docstring(cons, 4) %}
+    {%- call cs::method_throws_annotation(cons.throws_type()) %}
     public static {{ type_name }} {{ cons.name()|fn_name }}({% call cs::arg_list_decl(cons) %}) {
         return new {{ type_name }}({% call cs::to_ffi_call(cons) %});
     }

--- a/bindgen/templates/RecordTemplate.cs
+++ b/bindgen/templates/RecordTemplate.cs
@@ -4,8 +4,10 @@
 
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 
+{%- call cs::docstring(rec, 0) %}
 public record {{ type_name }} (
     {%- for field in rec.fields() %}
+    {%- call cs::docstring(field, 4) %}
     {{ field|type_name }} {{ field.name()|var_name -}}
     {%- match field.default_value() %}
         {%- when Some with(literal) %} = {{ literal|render_literal(field) }}

--- a/bindgen/templates/TopLevelFunctionTemplate.cs
+++ b/bindgen/templates/TopLevelFunctionTemplate.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
 
+{%- call cs::docstring(func, 4) %}
 {%- call cs::method_throws_annotation(func.throws_type()) %}
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -92,3 +92,11 @@ fun {{ func.name()|fn_name }}(
     {%- else -%}
     {%- endmatch %}
 {%- endmacro %}
+
+{%- macro docstring(defn, indent_spaces) %}
+{%- match defn.docstring() %}
+{%- when Some(docstring) %}
+{{ docstring|docstring(indent_spaces) }}
+{%- else %}
+{%- endmatch %}
+{%- endmacro %}

--- a/bindgen/templates/wrapper.cs
+++ b/bindgen/templates/wrapper.cs
@@ -1,6 +1,6 @@
 {#/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Common helper code.
 //
@@ -13,6 +13,7 @@
 // now that means coming from the exact some version of `uniffi` that was used to
 // compile the Rust component. The easiest way to ensure this is to bundle the C#
 // helpers directly inline like we're doing here.
+#}
 
 using System.IO;
 using System.Runtime.InteropServices;
@@ -22,6 +23,7 @@ using System;
 using {{ imported_class }};
 {%- endfor %}
 
+{%- call cs::docstring(ci.namespace_definition().unwrap(), 0) %}
 {%- match config.namespace %}
 {%- when Some(namespace) %}
 namespace {{ namespace }};

--- a/dotnet-tests/UniffiCS.binding_tests/TestDocstring.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestDocstring.cs
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using System.Text.RegularExpressions;
+using uniffi.uniffi_docstring;
+
+public class TestDocstring {
+    class CallbackImpls : CallbackTest {
+        public void Test() {}
+    }
+
+    [Fact]
+    public void DocstringWorks() {
+        // Checking to make sure the symbols are reachable,
+        // not accidentally commented out by docstrings
+
+        UniffiDocstringMethods.Test();
+
+        _ = EnumTest.ONE;
+
+        _ = new AssociatedEnumTest.Test();
+
+        _ = new ErrorTest.One("hello");
+
+        _ = new AssociatedErrorTest.Test();
+
+        var obj1 = new ObjectTest();
+        var obj2 = ObjectTest.NewAlternate();
+        obj2.Test();
+
+        var record = new RecordTest(123);
+        _ = record.test;
+
+        CallbackTest callback = new CallbackImpls();
+        callback.Test();
+    }
+
+    [Fact]
+    public void DocstringsAppearInBindings() {
+        // Hacky way to find project directory based on working directory..
+        string rootDirectory = Directory.GetCurrentDirectory() + "../../../../../../";
+
+        string uniffiTestSource = File.ReadAllText(rootDirectory + "3rd-party/uniffi-rs/fixtures/docstring/tests/test_generated_bindings.rs");
+        MatchCollection matches = Regex.Matches(uniffiTestSource, @"<docstring-.*>");
+        Assert.NotEmpty(matches);
+
+        string bindingsSource = File.ReadAllText(rootDirectory + "dotnet-tests/UniffiCS/gen/uniffi_docstring.cs");
+
+        List<string> missingDocstrings = matches
+            .Where(match => !bindingsSource.Contains(match.Value))
+            .Select(match => match.Value)
+            .ToList();
+
+        Assert.Empty(missingDocstrings);
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -19,5 +19,6 @@ uniffi-example-sprites = { path = "../3rd-party/uniffi-rs/examples/sprites" }
 uniffi-example-todolist = { path = "../3rd-party/uniffi-rs/examples/todolist" }
 uniffi-fixture-callbacks = { path = "../3rd-party/uniffi-rs/fixtures/callbacks" }
 uniffi-fixture-coverall = { path = "../3rd-party/uniffi-rs/fixtures/coverall" }
+uniffi-fixture-docstring = { path = "../3rd-party/uniffi-rs/fixtures/docstring" }
 uniffi-fixture-external-types = { path = "../3rd-party/uniffi-rs/fixtures/external-types/lib" }
 uniffi-fixture-time = { path = "../3rd-party/uniffi-rs/fixtures/uniffi-fixture-time" }

--- a/fixtures/disposable/src/lib.rs
+++ b/fixtures/disposable/src/lib.rs
@@ -9,8 +9,7 @@ use std::sync::{Arc, RwLock};
 static LIVE_COUNT: Lazy<RwLock<i32>> = Lazy::new(|| RwLock::new(0));
 
 #[derive(Debug, Clone)]
-pub struct Resource {
-}
+pub struct Resource {}
 
 impl Resource {
     pub fn new() -> Self {
@@ -55,30 +54,26 @@ fn get_resource() -> Arc<Resource> {
 
 fn get_resource_journal_list() -> ResourceJournalList {
     ResourceJournalList {
-        resources: vec!(get_resource(), get_resource()),
+        resources: vec![get_resource(), get_resource()],
     }
 }
 
 fn get_resource_journal_map() -> ResourceJournalMap {
     ResourceJournalMap {
-        resources: HashMap::from([
-            (1, get_resource()),
-            (2, get_resource()),
-        ]),
+        resources: HashMap::from([(1, get_resource()), (2, get_resource())]),
     }
 }
 
 fn get_resource_journal_map_list() -> ResourceJournalMapList {
     ResourceJournalMapList {
-        resources: HashMap::from([
-            (1, Some(vec!(get_resource(), get_resource()))),
-            (2, None),
-        ]),
+        resources: HashMap::from([(1, Some(vec![get_resource(), get_resource()])), (2, None)]),
     }
 }
 
 fn get_maybe_resource_journal() -> MaybeResourceJournal {
-    MaybeResourceJournal::Some { resource: get_resource_journal_list() }
+    MaybeResourceJournal::Some {
+        resource: get_resource_journal_list(),
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/disposable.uniffi.rs"));

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -11,10 +11,11 @@ mod uniffi_fixtures {
     uniffi_sprites::uniffi_reexport_scaffolding!();
     uniffi_todolist::uniffi_reexport_scaffolding!();
 
-    uniffi_fixture_callbacks::uniffi_reexport_scaffolding!();
     uniffi_chronological::uniffi_reexport_scaffolding!();
     uniffi_coverall::uniffi_reexport_scaffolding!();
     uniffi_external_types_lib::uniffi_reexport_scaffolding!();
+    uniffi_fixture_callbacks::uniffi_reexport_scaffolding!();
+    uniffi_fixture_docstring::uniffi_reexport_scaffolding!();
 
     uniffi_cs_disposable::uniffi_reexport_scaffolding!();
 }

--- a/test_bindings.sh
+++ b/test_bindings.sh
@@ -21,6 +21,7 @@ bindings 3rd-party/uniffi-rs/examples/sprites/src/sprites.udl
 bindings 3rd-party/uniffi-rs/examples/todolist/src/todolist.udl
 bindings 3rd-party/uniffi-rs/fixtures/callbacks/src/callbacks.udl
 bindings 3rd-party/uniffi-rs/fixtures/coverall/src/coverall.udl
+bindings 3rd-party/uniffi-rs/fixtures/docstring/src/docstring.udl
 bindings 3rd-party/uniffi-rs/fixtures/external-types/lib/src/external-types-lib.udl
 bindings 3rd-party/uniffi-rs/fixtures/uniffi-fixture-time/src/chronological.udl
 bindings fixtures/disposable/src/disposable.udl


### PR DESCRIPTION
I accidentally merged PR train in the wrong order :sweat_smile: Docstring PR was supposed to be merged to 0.24.0 before merging 0.24.0 to main.

This code was already reviewed at: https://github.com/NordSecurity/uniffi-bindgen-cs/pull/10