### PR TITLE
Turn off ImplicitUsings setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-cs"
-version = "0.2.3+v0.23.0"
+version = "0.2.4+v0.23.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ uses `uniffi-rs` version `0.20.0`.
 
 # How to install
 
-Minimum Rust version required to install `uniffi-bindgen-cs` is `1.58`.
+Minimum Rust version required to install `uniffi-bindgen-cs` is `1.64`.
 Newer Rust versions should also work fine.
 
 ```
@@ -25,13 +25,17 @@ Generates bindings file `path/to/definitions.cs`
 
 To integrate the bindings into your projects, simply add the generated bindings file to your project.
 There are a couple of requirements to compile the generated bindings file:
-- `dotnet` version `6.0` or higher
+- .NET core `6.0` or higher
 - allow `unsafe` code
-    ```
-    <PropertyGroup>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-    ```
+- allow `Nullable`
+
+```
+<PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+</PropertyGroup>
+```
 
 # Contributing
 

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cs"
-version = "0.2.3+v0.23.0"
+version = "0.2.4+v0.23.0"
 edition = "2021"
 
 [lib]

--- a/bindgen/templates/wrapper.cs
+++ b/bindgen/templates/wrapper.cs
@@ -15,9 +15,15 @@
 // helpers directly inline like we're doing here.
 #}
 
-using System.IO;
-using System.Runtime.InteropServices;
-using System;
+{#
+// Don't import directly to dedup and sort imports together with user defined
+// imports for custom types, e.g. `System` from `/uniffi-test-fixtures.toml`.
+#}
+{{- self.add_import("System") }}
+{{- self.add_import("System.Collections.Generic") }}
+{{- self.add_import("System.IO") }}
+{{- self.add_import("System.Linq") }}
+{{- self.add_import("System.Runtime.InteropServices") }}
 
 {%- for imported_class in self.imports() %}
 using {{ imported_class }};

--- a/dotnet-tests/UniffiCS.binding_tests/TestCallbacksFixture.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestCallbacksFixture.cs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections.Generic;
+using System.Linq;
 using System;
 using uniffi.fixture_callbacks;
 

--- a/dotnet-tests/UniffiCS.binding_tests/TestChronological.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestChronological.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Threading;
 using System;
 using uniffi.chronological;
 

--- a/dotnet-tests/UniffiCS.binding_tests/TestCoverall.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestCoverall.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Threading;
 using System;
 using uniffi.coverall;
 

--- a/dotnet-tests/UniffiCS.binding_tests/TestDocstring.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestDocstring.cs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using uniffi.uniffi_docstring;
 

--- a/dotnet-tests/UniffiCS.binding_tests/TestRondpoint.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestRondpoint.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections.Generic;
 using System.Globalization;
 using System;
 using uniffi.rondpoint;

--- a/dotnet-tests/UniffiCS.binding_tests/TestTodoList.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestTodoList.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections.Generic;
 using System;
 using uniffi.todolist;
 

--- a/dotnet-tests/UniffiCS.binding_tests/UniffiCS.binding_tests.csproj
+++ b/dotnet-tests/UniffiCS.binding_tests/UniffiCS.binding_tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/dotnet-tests/UniffiCS/UniffiCS.csproj
+++ b/dotnet-tests/UniffiCS/UniffiCS.csproj
@@ -2,12 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!-- Allow testing internals of generated code -->


### PR DESCRIPTION
The setting makes it a little bit easier to write new code, but it makes
it much harder to understand what dependencies the code has. Also,
relying on `ImplicitUsings` means that bindings consumers need to enable
this setting aswell.

Add missing imports for tests after disabling `ImplicitUsings`.

Fix import warning in `wrapper.cs` that appeared after turning off
`ImplicitUsings`.

Update README.md to reflect the actual Rust version requirement.

Update README.md with more accurate requirements for bindings consumers.