### PR TITLE
Fix bytes type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bytes-type"
+version = "1.0.0"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "uniffi",
+ "uniffi_macros",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1198,7 @@ dependencies = [
 name = "uniffi-bindgen-cs-fixtures"
 version = "0.1.0"
 dependencies = [
+ "bytes-type",
  "global-methods-class-name",
  "uniffi-cs-custom-types-builtin",
  "uniffi-cs-disposable-fixture",

--- a/bindgen/src/gen_cs/mod.rs
+++ b/bindgen/src/gen_cs/mod.rs
@@ -108,6 +108,12 @@ pub struct TypeAlias {
     original_type: String,
 }
 
+fn get_bytes_underlying_type() -> Type {
+    Type::Sequence {
+        inner_type: Box::new(Type::UInt8),
+    }
+}
+
 impl<'a> TypeRenderer<'a> {
     fn new(cs_config: &'a Config, ci: &'a ComponentInterface) -> Self {
         Self {
@@ -117,6 +123,23 @@ impl<'a> TypeRenderer<'a> {
             imports: RefCell::new(BTreeSet::new()),
             type_aliases: RefCell::new(BTreeSet::new()),
         }
+    }
+
+    fn get_cs_types(&self) -> BTreeSet<Type> {
+        let mut types: BTreeSet<Type> = self.ci.iter_types().cloned().collect();
+
+        // Replace Type::Bytes with Type::Sequence<u8>
+        if types.remove(&Type::Bytes) {
+            let bytes_type = get_bytes_underlying_type();
+            types.insert(bytes_type.clone());
+
+            match bytes_type {
+                Type::Sequence { inner_type } => types.insert(*inner_type),
+                _ => panic!("incorrect bytes type: {:?}", bytes_type),
+            };
+        }
+
+        types
     }
 
     // Get the package name for an external type
@@ -246,7 +269,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Float64 => Box::new(primitives::Float64CodeType),
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
-            Type::Bytes => Box::new(compounds::SequenceCodeType::new(Type::UInt8)),
+            Type::Bytes => get_bytes_underlying_type().as_codetype(),
 
             Type::Timestamp => Box::new(miscellany::TimestampCodeType),
             Type::Duration => Box::new(miscellany::DurationCodeType),

--- a/bindgen/templates/Types.cs
+++ b/bindgen/templates/Types.cs
@@ -4,7 +4,7 @@
 
 {%- import "macros.cs" as cs %}
 
-{%- for type_ in ci.iter_types() %}
+{%- for type_ in self.get_cs_types() %}
 {%- let type_name = type_|type_name %}
 {%- let ffi_converter_name = type_|ffi_converter_name %}
 {%- let canonical_type_name = type_|canonical_name %}
@@ -78,8 +78,7 @@
 {% include "SequenceTemplate.cs" %}
 
 {%- when Type::Bytes %}
-{%- let inner_type = Type::UInt8 %}
-{% include "SequenceTemplate.cs" %}
+{{ "Type::Bytes not supposed to be rendered"|panic }}
 
 {%- when Type::Map { key_type, value_type } %}
 {% include "MapTemplate.cs" %}

--- a/dotnet-tests/UniffiCS.binding_tests/TestBytesType.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestBytesType.cs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using System.Collections.Generic;
+using uniffi.bytes_type;
+
+// This test checks that `bytes` type emits correct code when
+// neither `Vec<u8>` nor `u8` are referenced in UDL file.
+
+public class TestBytesType {
+    [Fact]
+    public void TestBytesTypeWorks() {
+        Assert.Equal(new List<byte> { 3, 2, 1 }, BytesTypeMethods.Reverse(new List<byte> { 1, 2, 3 }));
+    }
+}

--- a/dotnet-tests/UniffiCS.binding_tests/TestCoverall.cs
+++ b/dotnet-tests/UniffiCS.binding_tests/TestCoverall.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections.Generic;
 using System.Threading;
 using System;
 using uniffi.coverall;
@@ -168,4 +169,10 @@ public class TestCoverall {
         }
     }
 
+    [Fact]
+    public void TestBytes() {
+        using (var coveralls = new Coveralls("test_bytes")) {
+            Assert.Equal(new List<byte> { 3, 2, 1 }, coveralls.Reverse(new List<byte> { 1, 2, 3 }));
+        }
+    }
 }

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+bytes-type = { path = "bytes-type" }
 global-methods-class-name = { path = "global-methods-class-name" }
 uniffi-cs-custom-types-builtin = { path = "custom-types-builtin" }
 uniffi-cs-disposable-fixture = { path = "disposable" }

--- a/fixtures/bytes-type/Cargo.toml
+++ b/fixtures/bytes-type/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bytes-type"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "bytes_type"
+
+[dependencies]
+once_cell = "1.12"
+thiserror = "1.0"
+uniffi = {path = "../../3rd-party/uniffi-rs/uniffi", features=["build"]}
+uniffi_macros = {path = "../../3rd-party/uniffi-rs/uniffi_macros"}
+
+[build-dependencies]
+uniffi = {path = "../../3rd-party/uniffi-rs/uniffi", features=["bindgen-tests"]}

--- a/fixtures/bytes-type/build.rs
+++ b/fixtures/bytes-type/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/bytes_type.udl").unwrap();
+}

--- a/fixtures/bytes-type/src/bytes_type.udl
+++ b/fixtures/bytes-type/src/bytes_type.udl
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+namespace bytes_type {
+    bytes reverse(bytes value);
+};

--- a/fixtures/bytes-type/src/lib.rs
+++ b/fixtures/bytes-type/src/lib.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub fn reverse(mut value: Vec<u8>) -> Vec<u8> {
+    value.reverse();
+    value
+}
+
+uniffi::include_scaffolding!("bytes_type");

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -17,6 +17,7 @@ mod uniffi_fixtures {
     uniffi_fixture_docstring::uniffi_reexport_scaffolding!();
     uniffi_trait_methods::uniffi_reexport_scaffolding!();
 
+    bytes_type::uniffi_reexport_scaffolding!();
     global_methods_class_name::uniffi_reexport_scaffolding!();
     uniffi_cs_custom_types_builtin::uniffi_reexport_scaffolding!();
     uniffi_cs_disposable::uniffi_reexport_scaffolding!();


### PR DESCRIPTION
`Type::Bytes` produces incorrect code in the following situations:
- `u8` is not referenced anywhere else in the definition file. This causes undefined symbol `FfiConverterUint8`.
- `Vec<u8>` is referenced somewhere in the definition file. This causes duplicate symbol definition for `FfiConverterSequenceUint8`.

To fix this, replace `Type::Bytes` with `Type::Sequence<u8>` in known types set before rendering `Type.cs`. This ensures that both FFI converters `FfiConverterSequenceUInt8` and `FfiConverterUInt8` will be rendered exactly once in `Types.cs`.

Fixes #49.