### PR TITLE
Fix error handling for command `dotnet csharpier`

### DIFF
--- a/bindgen/src/gen_cs/formatting.rs
+++ b/bindgen/src/gen_cs/formatting.rs
@@ -2,8 +2,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 pub fn format(bindings: String) -> Result<String, anyhow::Error> {
-    let mut csharpier = Command::new("dotnet")
-        .arg("csharpier")
+    let mut csharpier = Command::new("dotnet-csharpier")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;
@@ -15,6 +14,16 @@ pub fn format(bindings: String) -> Result<String, anyhow::Error> {
         .write_all(bindings.as_bytes())?;
 
     let output = csharpier.wait_with_output()?;
+    if !output.status.success() {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "command returned non-zero exit status: {:?}",
+                output.status.code()
+            ),
+        ))?;
+    }
+
     let formatted = String::from_utf8(output.stdout)?;
 
     Ok(formatted)

--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -130,7 +130,9 @@ pub fn main() -> Result<()> {
             .out_dir
             .expect("--out-dir is required when using --library");
         uniffi_bindgen::library_mode::generate_external_bindings(
-            BindingGenerator { try_format_code: !cli.no_format },
+            BindingGenerator {
+                try_format_code: !cli.no_format,
+            },
             &cli.source,
             cli.crate_name,
             cli.config.as_deref(),
@@ -139,7 +141,9 @@ pub fn main() -> Result<()> {
         .map(|_| ())
     } else {
         uniffi_bindgen::generate_external_bindings(
-            BindingGenerator { try_format_code: !cli.no_format },
+            BindingGenerator {
+                try_format_code: !cli.no_format,
+            },
             &cli.source,
             cli.config.as_deref(),
             cli.out_dir.as_deref(),


### PR DESCRIPTION
In Rust, command exit status has to be handled manually. Not handling exit status would cause the generator to generate invalid code when `dotnet` is installed, but `csharpier` is not installed.

Switch from using `dotnet csharpier` to using `dotnet-csharpier`. The former produces really verbose output by `dotnet` when `csharpier` is not installed or dotnet tools directory is not in PATH, while the latter returns a neat `command not found` error if CSharpier is not yet installed.