### PR TITLE
fix: force utc when converting DateTime values

### DIFF
--- a/bindgen/templates/TimestampHelper.cs
+++ b/bindgen/templates/TimestampHelper.cs
@@ -17,7 +17,7 @@ class FfiConverterTimestamp: FfiConverterRustBuffer<DateTime> {
         }
         var ticks = seconds * TimeSpan.TicksPerSecond;
         ticks += (nanoseconds / NanosecondsPerTick) * sign;
-        return DateTime.UnixEpoch.AddTicks(ticks);
+        return DateTime.UnixEpoch.ToUniversalTime().AddTicks(ticks);
     }
 
     public override int AllocationSize(DateTime value) {
@@ -26,7 +26,7 @@ class FfiConverterTimestamp: FfiConverterRustBuffer<DateTime> {
     }
 
     public override void Write(DateTime value, BigEndianStream stream) {
-        var epochOffset = value.Subtract(DateTime.UnixEpoch);
+        var epochOffset = value.ToUniversalTime().Subtract(DateTime.UnixEpoch);
 
         int sign = 1;
         if (epochOffset.Ticks < 0) {

--- a/dotnet-tests/UniffiCS.BindingTests/TestChronological.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestChronological.cs
@@ -45,7 +45,7 @@ public class TestChronological
     {
         Assert.Equal(DateTime.MinValue, ChronologicalMethods.ReturnTimestamp(DateTime.MinValue));
 
-        Assert.Equal(DateTime.MaxValue, ChronologicalMethods.ReturnTimestamp(DateTime.MaxValue));
+        Assert.Equal(DateTime.MaxValue.ToUniversalTime(), ChronologicalMethods.ReturnTimestamp(DateTime.MaxValue));
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class TestChronological
         );
 
         Assert.Equal(
-            DateTime.Parse("1955-11-05T00:06:01.283000200Z"),
+            DateTime.Parse("1955-11-05T00:06:01.283000200Z").ToUniversalTime(),
             ChronologicalMethods.Add(DateTime.Parse("1955-11-05T00:06:00.283000100Z"), TimeSpanSecond(1, 100))
         );
     }
@@ -86,11 +86,11 @@ public class TestChronological
     public void TestDateTimeWorksLikeRustSystemTime()
     {
         // Sleep inbetween to make sure that the clock has enough resolution
-        var before = DateTime.Now;
+        var before = DateTime.UtcNow;
         Thread.Sleep(1);
         var now = ChronologicalMethods.Now();
         Thread.Sleep(1);
-        var after = DateTime.Now;
+        var after = DateTime.UtcNow;
         Assert.Equal(-1, before.CompareTo(now));
         Assert.Equal(1, after.CompareTo(now));
     }


### PR DESCRIPTION
Alternative to #65

As far as I understand we need to pass UTC values to rust anyway, so by forcing UTC both ways we can avoid confusion and user error.