### PR TITLE
Downgrade .NET framework target version 4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ There are a few requirements depending on your target framework version.
     </PropertyGroup>
     ```
 
-- .NET framework `4.8`
+- .NET framework `4.6.1`
     ```xml
     <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
+        <TargetFramework>net461</TargetFramework>
         <LangVersion>10.0</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageReference Include="IsExternalInit" Version="1.0.3"/>

--- a/dotnet-tests/UniffiCS/UniffiCS.csproj
+++ b/dotnet-tests/UniffiCS/UniffiCS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
The generated bindings already support 4.6.1, update documentation and target framework version in test project settings.