### PR TITLE
Fix xml doc generation for fields in a record

### DIFF
--- a/bindgen/templates/RecordTemplate.cs
+++ b/bindgen/templates/RecordTemplate.cs
@@ -6,6 +6,19 @@
 {%- let (ordered_fields, is_reordered) = rec.fields()|order_fields %}
 
 {%- call cs::docstring(rec, 0) %}
+{%- for field in ordered_fields %}
+{%- match field.docstring() %}
+{%- when Some with(docstring) %}
+/// <param name="{{ field.name() }}">
+{%- let docstring = textwrap::dedent(docstring) %}
+{%- for line in docstring.lines() %}
+/// {{ line.trim_end() }}
+{%- endfor %}
+/// </param>
+{%- else %}
+{%- endmatch %}
+{%- endfor %}
+{%- let (ordered_fields, is_reordered) = rec.fields()|order_fields %}
 {%- if is_reordered %}
 /// <remarks>
 /// <b>UniFFI Warning:</b> Optional parameters have been reordered because
@@ -15,7 +28,6 @@
 {%- endif %}
 {{ config.access_modifier() }} record {{ type_name }} (
     {%- for field in ordered_fields %}
-    {%- call cs::docstring(field, 4) %}
     {{ field|type_name }} {{ field.name()|var_name -}}
     {%- match field.default_value() %}
         {%- when Some with(literal) %} = {{ literal|render_literal(field) }}


### PR DESCRIPTION
Before this change, field-style `/// <summary>` docs were emitted on the *parameters* of the record's primary constructor. But this is invalid C# syntax.

Docs on record properties that are defined via primary constructor parameters need to be written as parameter docs on the primary constructor.

### Expected

```cs
/// <param name="saplingRelativeSize">
/// Some doc
/// </param>
internal record AccountOptimizationSettings (
    float @saplingRelativeSize
) {
}
```

### Actual

```cs
internal record AccountOptimizationSettings(
	/// <summary>
	/// A non-negative number that will serve as the numerator when calculating the % of the shielded balance
	/// that should be maintained the sapling pool.
	/// The denominator is the sum of all shielded pool relative size fields.
	/// </summary>
	float @saplingRelativeSize,
) { }
```

And a C# warning:

> CS1587	XML comment is not placed on a valid language element	
