### PR TITLE
Fix short lived callback lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### UNRELEASED
+
+- **IMPORTANT**: Fix short-lived callback lifetimes (#79)
+
 ### v0.8.2+v0.25.0
 
 - Update C# callback syntax to work on iOS (#84)

--- a/bindgen/templates/CallbackInterfaceRuntime.cs
+++ b/bindgen/templates/CallbackInterfaceRuntime.cs
@@ -9,47 +9,59 @@ static class UniffiCallbackResponseCode {
 }
 
 class ConcurrentHandleMap<T> where T: notnull {
-    Dictionary<ulong, T> leftMap = new Dictionary<ulong, T>();
-    Dictionary<T, ulong> rightMap = new Dictionary<T, ulong>();
+    class Entry {
+        public Entry(T obj, ulong refcount, ulong handle) {
+            this.obj = obj;
+            this.refcount = refcount;
+            this.handle = handle;
+        }
+
+        public T obj;
+        public ulong refcount;
+        public ulong handle;
+    }
+
+    Dictionary<ulong, Entry> leftMap = new Dictionary<ulong, Entry>();
+    Dictionary<T, Entry> rightMap = new Dictionary<T, Entry>();
 
     Object lock_ = new Object();
     ulong currentHandle = 0;
 
     public ulong Insert(T obj) {
         lock (lock_) {
-            ulong existingHandle = 0;
-            if (rightMap.TryGetValue(obj, out existingHandle)) {
-                return existingHandle;
+            if (rightMap.TryGetValue(obj, out Entry? entry)) {
+                entry.refcount += 1;
+                return entry.handle;
             }
+
             currentHandle += 1;
-            leftMap[currentHandle] = obj;
-            rightMap[obj] = currentHandle;
-            return currentHandle;
+
+            Entry newEntry = new Entry(obj, 1, currentHandle);
+            leftMap[newEntry.handle] = newEntry;
+            rightMap[newEntry.obj] = newEntry;
+
+            return newEntry.handle;
         }
     }
 
-    public bool TryGet(ulong handle, out T result) {
-        // Possible null reference assignment
-        #pragma warning disable 8601
-        return leftMap.TryGetValue(handle, out result);
-        #pragma warning restore 8601
-    }
-
-    public bool Remove(ulong handle) {
-        return Remove(handle, out T result);
-    }
-
-    public bool Remove(ulong handle, out T result) {
+    public T Get(ulong handle) {
         lock (lock_) {
-            // Possible null reference assignment
-            #pragma warning disable 8601
-            if (leftMap.TryGetValue(handle, out result)) {
-            #pragma warning restore 8601
-                leftMap.Remove(handle);
-                rightMap.Remove(result);
-                return true;
-            } else {
-                return false;
+            if (leftMap.TryGetValue(handle, out Entry? entry)) {
+                return entry.obj;
+            }
+
+            throw new InternalException($"ConcurrentHandleMap::Get No callback in handlemap '{handle}'");
+        }
+    }
+
+    public void Remove(ulong handle) {
+        lock (lock_) {
+            if (leftMap.TryGetValue(handle, out Entry? entry)) {
+                entry.refcount -= 1;
+                if (entry.refcount < 1) {
+                    leftMap.Remove(entry.handle);
+                    rightMap.Remove(entry.obj);
+                }
             }
         }
     }
@@ -74,10 +86,7 @@ internal abstract class FfiConverterCallbackInterface<CallbackInterface>
     }
 
     public override CallbackInterface Lift(ulong handle) {
-        if (!handleMap.TryGet(handle, out CallbackInterface result)) {
-            throw new InternalException($"No callback in handlemap '{handle}'");
-        }
-        return result;
+        return handleMap.Get(handle);
     }
 
     public override CallbackInterface Read(BigEndianStream stream) {

--- a/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
@@ -189,4 +189,20 @@ public class TestCallbacksFixture
             );
         }
     }
+
+    [Fact]
+    public void ShortLivedCallbackDoesNotInvalidateLongerLivedCallback()
+    {
+        var stringifier = new CsharpStringifier();
+        using (var rustStringifier1 = new RustStringifier(stringifier))
+        {
+            using (var rustStringifier2 = new RustStringifier(stringifier))
+            {
+                Assert.Equal("C#: 123", rustStringifier2.FromSimpleType(123));
+            }
+            // `stringifier` must remain valid after `rustStringifier2` drops the reference
+
+            Assert.Equal("C#: 123", rustStringifier1.FromSimpleType(123));
+        }
+    }
 }

--- a/dotnet-tests/UniffiCS.BindingTests/TestNullToEmptyString.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestNullToEmptyString.cs
@@ -12,6 +12,8 @@ public class TestNullToEmptyString
     public void NullToEmptyStringWorks()
     {
         Assert.Equal("hello", LibGreeter.HelloWorld("hello"));
+        #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
         Assert.Equal("", LibGreeter.HelloWorld(null));
+        #pragma warning restore 8625
     }
 }

--- a/generate_bindings.sh
+++ b/generate_bindings.sh
@@ -6,4 +6,4 @@ GEN_DIR="dotnet-tests/UniffiCS/gen"
 rm -rf "$GEN_DIR"
 mkdir -p "$GEN_DIR"
 
-target/debug/uniffi-bindgen-cs target/debug/libuniffi_fixtures.so --library --out-dir="$GEN_DIR"
+target/debug/uniffi-bindgen-cs target/debug/libuniffi_fixtures.so --library --out-dir="$GEN_DIR" --no-format


### PR DESCRIPTION
Alternative to https://github.com/NordSecurity/uniffi-bindgen-cs/pull/88.

I like this one better, there is 1 less dictionary lookup.

I tried to use a struct ("stack" allocated), but C# does not allow to modify struct in-place in dictionary, so modifying refcount in a struct requires 2 lookups. Compared with a single object dereference in this MR, I think object dereference is the better option?