### PR TITLE
Fix short lived callback lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### UNRELEASED
+
+- **IMPORTANT**: Fix short-lived callback lifetimes (#79)
+
 ### v0.8.2+v0.25.0
 
 - Update C# callback syntax to work on iOS (#84)

--- a/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
@@ -189,4 +189,20 @@ public class TestCallbacksFixture
             );
         }
     }
+
+    [Fact]
+    public void ShortLivedCallbackDoesNotInvalidateLongerLivedCallback()
+    {
+        var stringifier = new CsharpStringifier();
+        using (var rustStringifier1 = new RustStringifier(stringifier))
+        {
+            using (var rustStringifier2 = new RustStringifier(stringifier))
+            {
+                Assert.Equal("C#: 123", rustStringifier2.FromSimpleType(123));
+            }
+            // `stringifier` must remain valid after `rustStringifier2` drops the reference
+
+            Assert.Equal("C#: 123", rustStringifier1.FromSimpleType(123));
+        }
+    }
 }

--- a/dotnet-tests/UniffiCS.BindingTests/TestNullToEmptyString.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestNullToEmptyString.cs
@@ -12,6 +12,8 @@ public class TestNullToEmptyString
     public void NullToEmptyStringWorks()
     {
         Assert.Equal("hello", LibGreeter.HelloWorld("hello"));
+        #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
         Assert.Equal("", LibGreeter.HelloWorld(null));
+        #pragma warning restore 8625
     }
 }

--- a/generate_bindings.sh
+++ b/generate_bindings.sh
@@ -6,4 +6,4 @@ GEN_DIR="dotnet-tests/UniffiCS/gen"
 rm -rf "$GEN_DIR"
 mkdir -p "$GEN_DIR"
 
-target/debug/uniffi-bindgen-cs target/debug/libuniffi_fixtures.so --library --out-dir="$GEN_DIR"
+target/debug/uniffi-bindgen-cs target/debug/libuniffi_fixtures.so --library --out-dir="$GEN_DIR" --no-format


### PR DESCRIPTION
Alternative to #89 and #88, this is the simplest solution, assigning unrelated ID for the same callback object. I like the simplicity of this, but in my mind it may be difficult to debug callback issues if callback ID is completely unrelated for the same callback. But maybe I'm overthinking this?