### PR TITLE
Bump v0.8.3+v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-### UNRELEASED
+### v0.8.3+v0.25.0
 
-- **IMPORTANT**: Fix short-lived callback lifetimes (#79)
+- **IMPORTANT**: Fix short-lived callback lifetimes [#79](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/79)
+- Fix xml doc generation for fields in a record (#87)
 
 ### v0.8.2+v0.25.0
 
-- Update C# callback syntax to work on iOS (#84)
+- Update C# callback syntax to work on iOS [#84](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/84)
 
 ### v0.8.1+v0.25.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-cs"
-version = "0.8.2+v0.25.0"
+version = "0.8.3+v0.25.0"
 dependencies = [
  "anyhow",
  "askama 0.11.1",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minimum Rust version required to install `uniffi-bindgen-cs` is `1.72`.
 Newer Rust versions should also work fine.
 
 ```bash
-cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.2+v0.25.0
+cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.3+v0.25.0
 ```
 
 # How to generate bindings

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cs"
-version = "0.8.2+v0.25.0"
+version = "0.8.3+v0.25.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Fixed links in CHANGELOG.md. Seems like Github links to MR with `#XX`. To link with issue, full markdown link form should be used. 

E.g. link with MR (there was no issue created): `Fix xml doc generation for fields in a record (#87)`

E.g. link with issue: `**IMPORTANT**: Fix short-lived callback lifetimes [#79](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/79)`