### PR TITLE
Fix enums/errors case names shadowing parameters to top level type names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "issue-60"
+version = "1.0.0"
+dependencies = [
+ "thiserror",
+ "uniffi",
+ "uniffi_macros",
+]
+
+[[package]]
 name = "issue-75"
 version = "1.0.0"
 dependencies = [
@@ -1227,6 +1236,7 @@ version = "0.1.0"
 dependencies = [
  "global-methods-class-name",
  "issue-28",
+ "issue-60",
  "issue-75",
  "issue-76",
  "null-to-empty-string",

--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ The following uniffi features are unsupported.
 
 - Async functions [#41](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/41)
 
-# Known Limitations
-
-The following valid Rust type definitions fail to be converted properly, but a simple work-around is given:
-
-- Enum variants having the same name as their member type [#60](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/60)
-
 # Configuration options
 
 It's possible to [configure some settings](docs/CONFIGURATION.md) by passing `--config`

--- a/bindgen/templates/EnumTemplate.cs
+++ b/bindgen/templates/EnumTemplate.cs
@@ -48,8 +48,8 @@ class {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     public record {{ variant.name()|class_name }}: {{ type_name }} {}
     {% else -%}
     public record {{ variant.name()|class_name }} (
-        {% for field in variant.fields() -%}
-        {{ field|type_name}} {{ field.name()|var_name }}{% if !loop.last %},{% endif %}
+        {%- for field in variant.fields() %}
+        {% call cs::enum_parameter_type_name(field|type_name, variant.name()|class_name) %} {{ field.name()|var_name }}{% if !loop.last %},{% endif %}
         {%- endfor %}
     ) : {{ type_name }} {}
     {%- endif %}

--- a/bindgen/templates/ErrorTemplate.cs
+++ b/bindgen/templates/ErrorTemplate.cs
@@ -64,13 +64,13 @@ class {{ ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>, CallSt
     public class {{ variant.name()|exception_name }} : {{ type_name }} {
         // Members
         {%- for field in variant.fields() %}
-        public {{ field|type_name}} {{ field.name()|var_name }};
+        public {% call cs::enum_parameter_type_name(field|type_name, variant.name()|exception_name) %} {{ field.name()|var_name }};
         {%- endfor %}
 
         // Constructor
         public {{ variant.name()|exception_name }}(
                 {%- for field in variant.fields() %}
-                {{ field|type_name}} {{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}
+                {% call cs::enum_parameter_type_name(field|type_name, variant.name()|exception_name) %} {{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}
                 {%- endfor %}) {
             {%- for field in variant.fields() %}
             this.{{ field.name()|var_name }} = {{ field.name()|var_name }};

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -122,3 +122,21 @@ void
 {%- endmatch -%}
 {%- endif -%}
 {%- endmacro -%}
+
+{#
+// Break the following cycle, where `Rectangle` case name shadow top level `Rectangle` type name.
+// If param type name matches the enum name, prefix the param type name with top level namespace.
+// https://github.com/NordSecurity/uniffi-bindgen-cs/issues/60
+//     public record Rectangle(double @width, double @height) { }
+//     public record Shape
+//     {                    ____________
+//                          ∨          ∧
+//         public record Rectangle(Rectangle @s) : Shape { }
+//         public record Ellipse(Ellipse @s) : Shape { }
+//     }
+#}
+{%- macro enum_parameter_type_name(param_type_name, enum_name) %}
+{%- if param_type_name == enum_name %}{{ config.namespace() }}.{{ param_type_name }}
+{%- else %}{{ param_type_name }}
+{%- endif %}
+{%- endmacro %}

--- a/dotnet-tests/UniffiCS.BindingTests/TestIssue60.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestIssue60.cs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using uniffi.issue_60;
+
+namespace UniffiCS.BindingTests;
+
+public class ClassIssue60
+{
+    [Fact]
+    public void TestIssue60()
+    {
+        new Shape.Rectangle(new Rectangle(1f, 2f));
+        new ShapeException.Rectangle(new Rectangle(1f, 2f));
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 global-methods-class-name = { path = "global-methods-class-name" }
 issue-28 = { path = "regressions/issue-28" }
+issue-60 = { path = "regressions/issue-60" }
 issue-75 = { path = "regressions/issue-75" }
 issue-76 = { path = "regressions/issue-76" }
 null-to-empty-string = { path = "null-to-empty-string" }

--- a/fixtures/regressions/issue-60/Cargo.toml
+++ b/fixtures/regressions/issue-60/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "issue-60"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "issue_60"
+
+[dependencies]
+thiserror = "1.0"
+uniffi = {path = "../../../3rd-party/uniffi-rs/uniffi", features=["build"]}
+uniffi_macros = {path = "../../../3rd-party/uniffi-rs/uniffi_macros"}
+
+[build-dependencies]
+uniffi = {path = "../../../3rd-party/uniffi-rs/uniffi", features=["bindgen-tests"]}

--- a/fixtures/regressions/issue-60/README.md
+++ b/fixtures/regressions/issue-60/README.md
@@ -1,0 +1,13 @@
+# https://github.com/NordSecurity/uniffi-bindgen-cs/issues/60
+
+Associated enum class names conflict with top level type definitions.
+
+```C#
+public record Rectangle(double @width, double @height) { }
+public record Shape
+{                    ____________
+                     ∨          ∧
+    public record Rectangle(Rectangle @s) : Shape { }
+    public record Ellipse(Ellipse @s) : Shape { }
+}
+```

--- a/fixtures/regressions/issue-60/src/lib.rs
+++ b/fixtures/regressions/issue-60/src/lib.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::fmt;
+
+#[derive(uniffi::Enum)]
+pub enum Shape {
+    Rectangle { s: Rectangle },
+    Ellipse { s: Ellipse },
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum ShapeError {
+    #[error("Rectangle: {s}")]
+    Rectangle { s: Rectangle },
+    #[error("Ellipse: {s}")]
+    Ellipse { s: Ellipse },
+}
+
+#[derive(uniffi::Record, Debug)]
+pub struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+#[derive(uniffi::Record, Debug)]
+pub struct Ellipse {
+    x_radius: f64,
+    y_radius: f64,
+}
+
+impl fmt::Display for Rectangle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "width: {}, height: {}", self.width, self.height)
+    }
+}
+
+impl fmt::Display for Ellipse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "x_radius: {}, y_radius: {}", self.x_radius, self.y_radius)
+    }
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -25,6 +25,7 @@ mod uniffi_fixtures {
     uniffi_cs_optional_parameters::uniffi_reexport_scaffolding!();
     stringify::uniffi_reexport_scaffolding!();
     issue_28::uniffi_reexport_scaffolding!();
+    issue_60::uniffi_reexport_scaffolding!();
     issue_75::uniffi_reexport_scaffolding!();
     issue_76::uniffi_reexport_scaffolding!();
 }


### PR DESCRIPTION
If associated enum class name matches it's parameter type name, prefix the parameter type with package namespace to restrict the compiler from picking the associated enum class instead of top level type definition

### Before
```
public record Rectangle(double @width, double @height) { }
public record Shape
{                    ____________
                     ∨          ∧
    public record Rectangle(Rectangle @s) : Shape { }
    public record Ellipse(Ellipse @s) : Shape { }
}
```

### After
```
namespace my_namespace;
public record Rectangle(double @width, double @height) { }
public record Shape ^_______________________
{                                           ^
    public record Rectangle(my_namespace.Rectangle @s) : Shape { }
    public record Ellipse(Ellipse @s) : Shape { }
}
```

Fixes https://github.com/NordSecurity/uniffi-bindgen-cs/issues/60

@itrumper 