### PR TITLE
Implement Eq and Hash trait methods

### DIFF
--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -82,16 +82,6 @@
         if (obj is null || !(obj is {{type_name}})) return false;
         return Equals(obj as {{type_name}});
     }
-    public static bool operator == ({{type_name}}? a, {{type_name}}? b)
-    {
-        if (a is null || b is null) return Object.Equals(a, b);
-        return a.Equals(b);
-    }
-    public static bool operator != ({{type_name}}? a, {{type_name}}? b)
-    {
-        if (a is null || b is null) return !Object.Equals(a, b);
-        return !(a.Equals(b));
-    }
     {%- when UniffiTrait::Hash  { hash }  %}
     public override int GetHashCode() { 
         return (int){{ Type::UInt64.borrow()|lift_fn }}({%- call cs::to_ffi_call_with_prefix("this.GetHandle()", hash)  %});

--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -9,10 +9,9 @@
 {%- call cs::docstring(obj, 0) %}
 {{ config.access_modifier() }} interface I{{ type_name }}
     {%- for tm in obj.uniffi_traits() -%}
-    {%- if loop.first -%} : {% endif -%}
     {%- match tm -%}
     {%- when UniffiTrait::Eq { eq, ne } -%}
-    IEquatable<{{type_name}}>
+    : IEquatable<{{type_name}}>
     {%- else -%}
     {%- endmatch -%}
     {%- endfor %} {

--- a/dotnet-tests/UniffiCS.BindingTests/TestTraitMethod.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestTraitMethod.cs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Generic;
 using uniffi.trait_methods;
 
 namespace UniffiCS.BindingTests;
@@ -9,7 +11,7 @@ namespace UniffiCS.BindingTests;
 public class TestTraitMethods
 {
     [Fact]
-    public void TraitMethodsWork()
+    public void TestDisplay()
     {
         using (var methods = new TraitMethods("yo"))
         {
@@ -18,11 +20,118 @@ public class TestTraitMethods
     }
 
     [Fact]
-    public void TraitMethodsProcMacro()
+    public void TestEq()
+    {
+        using (var methods = new TraitMethods("yo"))
+        {
+            Assert.Equal(methods, new TraitMethods("yo"));
+            Assert.True(methods == new TraitMethods("yo"));
+
+            Assert.Equal(methods, methods);
+
+            Assert.NotEqual(methods, new TraitMethods("yoyo"));
+            Assert.True(methods != new TraitMethods("yoyo"));
+        }
+
+        Assert.False(new TraitMethods("yo") == null);
+    }
+
+    [Fact]
+    public void TestEqNulls()
+    {
+        TraitMethods? t1 = null;
+        TraitMethods? t2 = null;
+        Assert.True(Object.Equals(t1, t2));
+
+        t1 = new TraitMethods("yo");
+        Assert.False(Object.Equals(t1, t2));
+        
+        Assert.False(new TraitMethods("yo") == null);
+        Assert.True(new TraitMethods("yo") != null);
+    }
+
+    [Fact]
+    public void TestEqContains() 
+    {
+        var tm = new TraitMethods("yo");
+        var list = new List<TraitMethods>();
+        list.Add(tm);
+
+        Assert.Contains(tm, list);
+        Assert.Contains(new TraitMethods("yo"), list);
+        Assert.DoesNotContain(null, list);
+        Assert.DoesNotContain(new TraitMethods("yoyo"), list);
+    }
+
+   [Fact]
+   public void TestHash()
+   {
+       using (var methods = new TraitMethods("yo"))
+       {
+           Assert.Equal(methods.GetHashCode(), new TraitMethods("yo").GetHashCode());
+           Assert.NotEqual(methods.GetHashCode(), new TraitMethods("yoyo").GetHashCode());
+       }
+   }
+}
+
+public class TestProcMacroTraitMethods
+{
+    [Fact]
+    public void TestDisplay()
     {
         using (var methods = new ProcTraitMethods("yo"))
         {
             Assert.Equal("ProcTraitMethods(yo)", methods.ToString());
+        }
+    }
+
+   [Fact]
+    public void TestEq()
+    {
+        using (var methods = new ProcTraitMethods("yo"))
+        {
+            Assert.Equal(methods, new ProcTraitMethods("yo"));
+            Assert.True(methods == new ProcTraitMethods("yo"));
+
+            Assert.Equal(methods, methods);
+
+            Assert.NotEqual(methods, new ProcTraitMethods("yoyo"));
+            Assert.True(methods != new ProcTraitMethods("yoyo"));
+        }
+
+        Assert.False(new ProcTraitMethods("yo") == null);
+    }
+
+    [Fact]
+    public void TestEqNulls()
+    {
+        ProcTraitMethods? t1 = null;
+        ProcTraitMethods? t2 = null;
+        Assert.True(Object.Equals(t1, t2));
+        
+        Assert.False(new ProcTraitMethods("yo") == null);
+    }
+
+    [Fact]
+    public void TestEqContains() 
+    {
+        var tm = new ProcTraitMethods("yo");
+        var list = new List<ProcTraitMethods>();
+        list.Add(tm);
+
+        Assert.Contains(tm, list);
+        Assert.Contains(new ProcTraitMethods("yo"), list);
+        Assert.DoesNotContain(null, list);
+        Assert.DoesNotContain(new ProcTraitMethods("yoyo"), list);
+    }
+
+    [Fact]
+    public void TestHash()
+    {
+        using (var methods = new ProcTraitMethods("yo"))
+        {
+            Assert.Equal(methods.GetHashCode(), new ProcTraitMethods("yo").GetHashCode());
+            Assert.NotEqual(methods.GetHashCode(), new ProcTraitMethods("yoyo").GetHashCode());
         }
     }
 }

--- a/dotnet-tests/UniffiCS.BindingTests/TestTraitMethod.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestTraitMethod.cs
@@ -24,20 +24,17 @@ public class TestTraitMethods
     {
         using (var methods = new TraitMethods("yo"))
         {
+            // Values are equal if input is the same
             Assert.Equal(methods, new TraitMethods("yo"));
-            Assert.True(methods == new TraitMethods("yo"));
-
-            Assert.Equal(methods, methods);
-
             Assert.NotEqual(methods, new TraitMethods("yoyo"));
-            Assert.True(methods != new TraitMethods("yoyo"));
-        }
 
-        Assert.False(new TraitMethods("yo") == null);
+            // Values are not referentially equal
+            Assert.False(methods == new TraitMethods("yo"));
+        }
     }
 
     [Fact]
-    public void TestEqNulls()
+    public void TestEqNull()
     {
         TraitMethods? t1 = null;
         TraitMethods? t2 = null;
@@ -54,8 +51,10 @@ public class TestTraitMethods
     public void TestEqContains() 
     {
         var tm = new TraitMethods("yo");
-        var list = new List<TraitMethods>();
-        list.Add(tm);
+        var list = new List<TraitMethods>
+        {
+            tm
+        };
 
         Assert.Contains(tm, list);
         Assert.Contains(new TraitMethods("yo"), list);
@@ -90,20 +89,17 @@ public class TestProcMacroTraitMethods
     {
         using (var methods = new ProcTraitMethods("yo"))
         {
+            // Values are equal if input is the same
             Assert.Equal(methods, new ProcTraitMethods("yo"));
-            Assert.True(methods == new ProcTraitMethods("yo"));
-
-            Assert.Equal(methods, methods);
-
             Assert.NotEqual(methods, new ProcTraitMethods("yoyo"));
-            Assert.True(methods != new ProcTraitMethods("yoyo"));
-        }
 
-        Assert.False(new ProcTraitMethods("yo") == null);
+            // Values are not referentially equal
+            Assert.False(methods == new ProcTraitMethods("yo"));
+        }
     }
 
     [Fact]
-    public void TestEqNulls()
+    public void TestEqNull()
     {
         ProcTraitMethods? t1 = null;
         ProcTraitMethods? t2 = null;
@@ -116,8 +112,10 @@ public class TestProcMacroTraitMethods
     public void TestEqContains() 
     {
         var tm = new ProcTraitMethods("yo");
-        var list = new List<ProcTraitMethods>();
-        list.Add(tm);
+        var list = new List<ProcTraitMethods>
+        {
+            tm
+        };
 
         Assert.Contains(tm, list);
         Assert.Contains(new ProcTraitMethods("yo"), list);


### PR DESCRIPTION
Hello! Thanks for maintaining this project, it's really been a lifesaver. 
I've implemented the `Eq` and `Hash` traits, skipping `Debug` because I'm not aware of a parallel in .NET. 
One caveat to note, if `Eq` is implemented but `Hash` is not, .NET will show a warning that `Object.GetHashCode()` should be overwritten as well. If they don't overwrite it, dictionaries/hashmaps and such might not work as expected.

We've been making heavy use of this crate at my org, and this contribution is really an attempt to get my feet wet in the repo with the hope of assisting with the async implementation. Any guidance/warnings on that front would be very appreciated. :) 