### PR TITLE
Use lower case string type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "issue-110"
+version = "1.0.0"
+dependencies = [
+ "uniffi 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "issue-28"
 version = "0.1.0"
 dependencies = [
@@ -1156,6 +1164,7 @@ name = "uniffi-bindgen-cs-fixtures"
 version = "0.1.0"
 dependencies = [
  "global-methods-class-name",
+ "issue-110",
  "issue-28",
  "issue-60",
  "issue-75",

--- a/bindgen/src/gen_cs/filters.rs
+++ b/bindgen/src/gen_cs/filters.rs
@@ -34,6 +34,7 @@ pub(super) fn type_name_custom(
         Type::UInt64 => Ok("UInt64".to_string()),
         Type::Float32 => Ok("Single".to_string()),
         Type::Float64 => Ok("Double".to_string()),
+        Type::String => Ok("String".to_string()),
         _ => type_name(typ, ci),
     }
 }

--- a/bindgen/src/gen_cs/primitives.rs
+++ b/bindgen/src/gen_cs/primitives.rs
@@ -76,7 +76,7 @@ macro_rules! impl_code_type_for_primitive {
 }
 
 impl_code_type_for_primitive!(BooleanCodeType, "bool", "Boolean");
-impl_code_type_for_primitive!(StringCodeType, "String", "String");
+impl_code_type_for_primitive!(StringCodeType, "string", "String");
 impl_code_type_for_primitive!(Int8CodeType, "sbyte", "Int8");
 impl_code_type_for_primitive!(Int16CodeType, "short", "Int16");
 impl_code_type_for_primitive!(Int32CodeType, "int", "Int32");

--- a/dotnet-tests/UniffiCS.BindingTests/TestIssue110.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestIssue110.cs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using uniffi.issue_110;
+
+namespace UniffiCS.BindingTests;
+
+public class ClassIssue110
+{
+    [Fact]
+    public void TestIssue110()
+    {
+        var @string = new Value.String("test");
+        Assert.Equal("test", @string.value);
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -14,6 +14,7 @@ issue-28 = { path = "regressions/issue-28" }
 issue-60 = { path = "regressions/issue-60" }
 issue-75 = { path = "regressions/issue-75" }
 issue-76 = { path = "regressions/issue-76" }
+issue-110 = { path = "regressions/issue-110" }
 null-to-empty-string = { path = "null-to-empty-string" }
 uniffi-cs-custom-types-builtin = { path = "custom-types-builtin" }
 uniffi-cs-disposable-fixture = { path = "disposable" }

--- a/fixtures/regressions/issue-110/Cargo.toml
+++ b/fixtures/regressions/issue-110/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "issue-110"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "issue_110"
+
+[dependencies]
+uniffi = { workspace = true, features = ["build"] }
+uniffi_macros.workspace = true
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/issue-110/README.md
+++ b/fixtures/regressions/issue-110/README.md
@@ -1,0 +1,3 @@
+# https://github.com/NordSecurity/uniffi-bindgen-cs/issues/110
+
+Builtin string types are generated using the builtin c# keyword.

--- a/fixtures/regressions/issue-110/build.rs
+++ b/fixtures/regressions/issue-110/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::generate_scaffolding("src/issue-110.udl").unwrap();
+}

--- a/fixtures/regressions/issue-110/src/issue-110.udl
+++ b/fixtures/regressions/issue-110/src/issue-110.udl
@@ -1,0 +1,13 @@
+namespace issue_110 {
+
+};
+
+[Enum]
+interface Value{
+    Null();
+    Bool(boolean value);
+    Double(f64 value);
+    I64(i64 value);
+    Binary(bytes value);
+    String(string value);
+};

--- a/fixtures/regressions/issue-110/src/lib.rs
+++ b/fixtures/regressions/issue-110/src/lib.rs
@@ -1,0 +1,10 @@
+pub enum Value {
+    Null,
+    Bool { value: bool },
+    Double { value: f64 },
+    I64 { value: i64 },
+    Binary { value: Vec<u8> },
+    String { value: String }
+}
+
+uniffi::include_scaffolding!("issue-110");

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -31,4 +31,5 @@ mod uniffi_fixtures {
     issue_60::uniffi_reexport_scaffolding!();
     issue_75::uniffi_reexport_scaffolding!();
     issue_76::uniffi_reexport_scaffolding!();
+    issue_110::uniffi_reexport_scaffolding!();
 }


### PR DESCRIPTION
This is done so that capitalized string types defined in the udl file are distinct from the builtin string type

Fixes #110 