### PR TITLE
Allow config file to be specified alongside --library

### DIFF
--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -31,7 +31,7 @@ struct Cli {
     lib_file: Option<Utf8PathBuf>,
 
     /// Pass in a cdylib path rather than a UDL file
-    #[clap(long = "library", conflicts_with_all = &["config", "lib-file"], requires = "out-dir")]
+    #[clap(long = "library", conflicts_with_all = &["lib-file"], requires = "out-dir")]
     library_mode: bool,
 
     /// When `--library` is passed, only generate bindings for one crate


### PR DESCRIPTION
I noticed that providing a config file is already supported in the code but prevented by the command line arguments validation. Removing that validation restriction allows me to successfully provide a config file.

fixes https://github.com/NordSecurity/uniffi-bindgen-cs/issues/119
