### PR TITLE
Fixes heavy code on dispose.

### DIFF
--- a/bindgen/templates/Helpers.cs
+++ b/bindgen/templates/Helpers.cs
@@ -140,29 +140,50 @@ static class FFIObjectUtil {
     // Dispose is implemented by recursive type inspection at runtime. This is because
     // generating correct Dispose calls for recursive complex types, e.g. List<List<int>>
     // is quite cumbersome.
-    private static void Dispose(dynamic? obj) {
-        if (obj == null) {
-            return;
-        }
+   private static void Dispose(Object? obj) {
+         if (obj == null) {
+             return;
+         }
 
-        if (obj is IDisposable disposable) {
-            disposable.Dispose();
-            return;
-        }
+         if (obj is IDisposable disposable) {
+             disposable.Dispose();
+             return;
+         }
 
-        var type = obj.GetType();
-        if (type != null) {
-            if (type.IsGenericType) {
-                if (type.GetGenericTypeDefinition().IsAssignableFrom(typeof(List<>))) {
-                    foreach (var value in obj) {
-                        Dispose(value);
-                    }
-                } else if (type.GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>))) {
-                    foreach (var value in obj.Values) {
-                        Dispose(value);
-                    }
-                }
-            }
-        }
-    }
+         var objType = obj.GetType();
+         var typeCode = Type.GetTypeCode(objType);
+         if (typeCode != TypeCode.Object) {
+             return;
+         }
+
+         var genericArguments = objType.GetGenericArguments();
+         if (genericArguments.Length == 0) {
+             return;
+         }
+
+         if (obj is System.Collections.IDictionary objDictionary) {
+            //This extra code tests to not call "Dispose" for a Dictionary<something, double>()
+            //for all keys as "double" and alike doesn't support interface "IDisposable"
+             var valuesType = objType.GetGenericArguments()[1];
+             var elementValuesTypeCode = Type.GetTypeCode(valuesType);
+             if (elementValuesTypeCode != TypeCode.Object) {
+                 return;
+             }
+             foreach (var value in objDictionary.Values) {
+                 Dispose(value);
+             }
+         }
+         else if (obj is System.Collections.IEnumerable listValues) {
+            //This extra code tests to not call "Dispose" for a List<int>()
+            //for all keys as "int" and alike doesn't support interface "IDisposable"
+             var valuesType = objType.GetGenericArguments()[0];
+             var elementValuesTypeCode = Type.GetTypeCode(valuesType);
+             if (elementValuesTypeCode != TypeCode.Object) {
+                 return;
+             }
+             foreach (var value in listValues) {
+                 Dispose(value);
+             }
+         }
+     }
 }


### PR DESCRIPTION
It should fix issue #128 

Considerations:
There's no reflection (especially not as heavy as "dynamic") minus very lightweight constructs (`is`) that are very fast.

This new implementation now supports all "IEnumerable" items to be deconstructed nicely, including but not limited to: Queue<T>, ConcurrentDictionary<K,V> and alike.

It also avoid calling to test "Dispose" when the collection is of primitive values.