### PR TITLE
Use sequence collection to be System.Array

### DIFF
--- a/bindgen/src/gen_cs/compounds.rs
+++ b/bindgen/src/gen_cs/compounds.rs
@@ -58,7 +58,7 @@ macro_rules! impl_code_type_for_compound {
  }
 
 impl_code_type_for_compound!(OptionalCodeType, "{}?", "Optional{}");
-impl_code_type_for_compound!(SequenceCodeType, "List<{}>", "Sequence{}");
+impl_code_type_for_compound!(SequenceCodeType, "{}[]", "Sequence{}");
 
 #[derive(Debug)]
 pub struct MapCodeType {

--- a/bindgen/templates/BigEndianStream.cs
+++ b/bindgen/templates/BigEndianStream.cs
@@ -107,6 +107,12 @@ static class BigEndianStreamExtensions
             throw new StreamUnderflowException();
         }
     }
+
+    public static void ForEach<T>(this T[] items, Action<T> action){
+        foreach (var item in items) {
+            action(item);
+        }
+    }
 }
 
 class BigEndianStream {

--- a/bindgen/templates/Helpers.cs
+++ b/bindgen/templates/Helpers.cs
@@ -132,9 +132,7 @@ class _UniffiHelpers {
 
 static class FFIObjectUtil {
     public static void DisposeAll(params Object?[] list) {
-        foreach (var obj in list) {
-            Dispose(obj);
-        }
+        Dispose(list);
     }
 
     // Dispose is implemented by recursive type inspection at runtime. This is because
@@ -157,13 +155,13 @@ static class FFIObjectUtil {
          }
 
          var genericArguments = objType.GetGenericArguments();
-         if (genericArguments.Length == 0) {
+         if (genericArguments.Length == 0 && !objType.IsArray) {
              return;
          }
 
          if (obj is System.Collections.IDictionary objDictionary) {
-            //This extra code tests to not call "Dispose" for a Dictionary<something, double>()
-            //for all keys as "double" and alike doesn't support interface "IDisposable"
+             //This extra code tests to not call "Dispose" for a Dictionary<something, double>()
+             //for all values as "double" and alike doesn't support interface "IDisposable"
              var valuesType = objType.GetGenericArguments()[1];
              var elementValuesTypeCode = Type.GetTypeCode(valuesType);
              if (elementValuesTypeCode != TypeCode.Object) {
@@ -174,10 +172,10 @@ static class FFIObjectUtil {
              }
          }
          else if (obj is System.Collections.IEnumerable listValues) {
-            //This extra code tests to not call "Dispose" for a List<int>()
-            //for all keys as "int" and alike doesn't support interface "IDisposable"
-             var valuesType = objType.GetGenericArguments()[0];
-             var elementValuesTypeCode = Type.GetTypeCode(valuesType);
+             //This extra code tests to not call "Dispose" for a List<int>()
+             //for all keys as "int" and alike doesn't support interface "IDisposable"
+             var elementType = objType.IsArray ? objType.GetElementType() : genericArguments[0];
+             var elementValuesTypeCode = Type.GetTypeCode(elementType);
              if (elementValuesTypeCode != TypeCode.Object) {
                  return;
              }

--- a/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestCallbacksFixture.cs
@@ -42,10 +42,8 @@ class CsharpGetters : ForeignGetters
         return arg2 && v != null ? v.ToUpper() : v;
     }
 
-    public List<Int32> GetList(List<Int32> v, Boolean arg2)
-    {
-        return arg2 ? v : new List<Int32>();
-    }
+    public int[] GetList(int[] v, bool arg2)
+        => arg2 ? v : [];
 
     public void GetNothing(String v)
     {
@@ -64,10 +62,10 @@ class CsharpStringifier : StoredForeignStringifier
 {
     public String FromSimpleType(Int32 value)
     {
-        return "C#: " + value.ToString();
+        return "C#: " + value;
     }
 
-    public String FromComplexType(List<Double?>? values)
+    public String FromComplexType(Double?[]? values)
     {
         if (values == null)
         {
@@ -75,10 +73,7 @@ class CsharpStringifier : StoredForeignStringifier
         }
         else
         {
-            var stringValues = values.Select(number =>
-            {
-                return number == null ? "null" : number.ToString();
-            });
+            var stringValues = values.Select(number => { return number == null ? "null" : number.ToString(); });
             return "C#: " + string.Join(" ", stringValues);
         }
     }
@@ -98,13 +93,13 @@ public class TestCallbacksFixture
                 Assert.Equal(callback.GetBool(v, flag), rustGetters.GetBool(callback, v, flag));
             }
 
-            foreach (
-                var v in new List<List<Int32>>
-                {
-                    new List<Int32> { 1, 2 },
-                    new List<Int32> { 0, 1 }
-                }
-            )
+            Int32[][] items =
+            [
+                [1, 2],
+                [0, 1]
+            ];
+
+            foreach (var v in items)
             {
                 var flag = true;
                 Assert.Equal(callback.GetList(v, flag), rustGetters.GetList(callback, v, flag));

--- a/dotnet-tests/UniffiCS.BindingTests/TestCoverall.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestCoverall.cs
@@ -173,7 +173,7 @@ public class TestCoverall
         {
             coveralls.AddPatch(new Patch(Color.Red));
             coveralls.AddRepair(new Repair(DateTime.Now, new Patch(Color.Blue)));
-            Assert.Equal(2, coveralls.GetRepairs().Count);
+            Assert.Equal(2, coveralls.GetRepairs().Length);
         }
     }
 
@@ -236,9 +236,9 @@ public class TestCoverall
             }
         }
 
-        public List<Int32> GetList(List<Int32> v, Boolean arg2)
+        public int[] GetList(int[] v, Boolean arg2)
         {
-            return arg2 ? v : new List<Int32>();
+            return arg2 ? v : [];
         }
 
 
@@ -265,9 +265,9 @@ public class TestCoverall
         Assert.Equal("hello", getters.GetOption("hello", false));
         Assert.Null(getters.GetOption("", true));
 
-        var l = new List<Int32> {1, 2, 3};
+        int[] l = [1, 2, 3];
         Assert.Equal(l, getters.GetList(l, true));
-        Assert.Equal(new List<Int32>(), getters.GetList(l, false));
+        Assert.Equal([], getters.GetList(l, false));
 
         getters.GetNothing("hello");
 

--- a/dotnet-tests/UniffiCS.BindingTests/TestErrorTypes.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestErrorTypes.cs
@@ -13,7 +13,7 @@ public class TestErrorTypes
     {
         var e = Assert.Throws<ErrorInterface>(() => ErrorTypesMethods.Oops());
         Assert.Equal("because uniffi told me so\n\nCaused by:\n    oops", e.ToString());
-        Assert.Equal(2, e.Chain().Count);
+        Assert.Equal(2, e.Chain().Length);
         Assert.Equal("because uniffi told me so", e.Link(0));
     }
 
@@ -22,7 +22,7 @@ public class TestErrorTypes
     {
         var e = Assert.Throws<ErrorInterface>(() => ErrorTypesMethods.OopsNowrap());
         Assert.Equal("because uniffi told me so\n\nCaused by:\n    oops", e.ToString());
-        Assert.Equal(2, e.Chain().Count);
+        Assert.Equal(2, e.Chain().Length);
         Assert.Equal("because uniffi told me so", e.Link(0));
     }
 

--- a/dotnet-tests/UniffiCS.BindingTests/TestRondpoint.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestRondpoint.cs
@@ -20,7 +20,7 @@ public class TestRondpoint
         Assert.Equal(Enumeration.Deux, RondpointMethods.CopieEnumeration(Enumeration.Deux));
 
         var list = new List<Enumeration>() { Enumeration.Un, Enumeration.Deux };
-        Assert.Equal(list, RondpointMethods.CopieEnumerations(list));
+        Assert.Equal(list, RondpointMethods.CopieEnumerations(list.ToArray()));
 
         var dict = new Dictionary<String, EnumerationAvecDonnees>()
         {
@@ -203,7 +203,7 @@ public class TestRondpoint
 
         AffirmAllerRetour(op.SinonString, "foo", "bar");
         AffirmAllerRetour(op.SinonBoolean, true, false);
-        AffirmAllerRetour(op.SinonSequence, new List<String>() { "foo", "bar" }, new List<String>());
+        AffirmAllerRetour<string[]>(op.SinonSequence, [[ "foo", "bar" ]]);
 
         // Optionals
 #pragma warning disable 8621
@@ -276,7 +276,7 @@ public class TestRondpoint
             // a default list value (null) is transformed into an empty list after a roundtrip
             defaultes = defaultes with
             {
-                listVar = new List<String>()
+                listVar = []
             };
 
             // TODO(CS): C# record comparison doesn't work if the record contains lists/maps.

--- a/dotnet-tests/UniffiCS.BindingTests/TestTodoList.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestTodoList.cs
@@ -36,14 +36,14 @@ public class TestTodoList
         todo.AddEntry(entry2);
         Assert.Equal("Test Ünicode hàndling in an entry 🤣", todo.GetLastEntry().text);
 
-        Assert.Equal(5, todo.GetEntries().Count);
+        Assert.Equal(5, todo.GetEntries().Length);
 
-        todo.AddEntries(new List<TodoEntry>() { new TodoEntry("foo"), new TodoEntry("bar") });
-        Assert.Equal(7, todo.GetEntries().Count);
+        todo.AddEntries([new TodoEntry("foo"), new TodoEntry("bar") ]);
+        Assert.Equal(7, todo.GetEntries().Length);
         Assert.Equal("bar", todo.GetLastEntry().text);
 
-        todo.AddItems(new List<string>() { "bobo", "fofo" });
-        Assert.Equal(9, todo.GetItems().Count);
+        todo.AddItems([ "bobo", "fofo"] );
+        Assert.Equal(9, todo.GetItems().Length);
         Assert.Equal("bobo", todo.GetItems()[7]);
 
         Assert.Null(TodolistMethods.GetDefaultList());

--- a/dotnet-tests/UniffiCS.BindingTests/TestTraits.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestTraits.cs
@@ -18,7 +18,7 @@ public class TestTraits
         foreach (var button in TraitsMethods.GetButtons())
         {
             var name = button.Name();
-            Assert.Contains(name, new string[] {"go", "stop"});
+            Assert.Contains(name, ["go", "stop"]);
             Assert.Equal(TraitsMethods.Press(button).Name(), name);
         }
     }


### PR DESCRIPTION
Reduces memory consumption, and most changes are "Count" (is the List's length) vs "Length" (array's one).

All tests are passing.

Fixes #137 