### PR TITLE
Update docker image to use sdk:9.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.88
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
@@ -25,7 +25,7 @@ jobs:
   test-bindings:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.1.0
+      image: ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.2.1
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0
 
 LABEL org.opencontainers.image.source=https://github.com/NordSecurity/uniffi-bindgen-cs
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.88
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
 

--- a/docker.sh
+++ b/docker.sh
@@ -5,4 +5,4 @@ docker run \
     -ti --rm \
     --volume $PWD:/mounted_workdir \
     --workdir /mounted_workdir \
-    ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.1.0 bash
+    ghcr.io/nordsecurity/uniffi-bindgen-cs-test-runner:v0.2.1 bash

--- a/dotnet-tests/UniffiCS.BindingTests/UniffiCS.BindingTests.csproj
+++ b/dotnet-tests/UniffiCS.BindingTests/UniffiCS.BindingTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/dotnet-tests/UniffiCS/UniffiCS.csproj
+++ b/dotnet-tests/UniffiCS/UniffiCS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>warnings</Nullable>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "1.88"


### PR DESCRIPTION
This PR updates the docker image used in CI:
- Update dotnet sdk to 9.0
- Bump rust version to 1.88