### PR TITLE
[Backport #143] Fix callback vtable lifetime

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -2,9 +2,9 @@ name: C#
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "main-v0.28.3" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "main-v0.28.3" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### UNRELEASED
 
+### v0.9.2+v0.28.3
+- Fix vtable callback lifetimes
+
 ### v0.9.1+v0.28.3
 - Add calling convention cdecl to DllImport
 - User type "String" shadows native type System.String [#110](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/110)

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cs"
-version = "0.9.0+v0.28.3"
+version = "0.9.2+v0.28.3"
 edition = "2021"
 
 [lib]

--- a/bindgen/src/gen_cs/mod.rs
+++ b/bindgen/src/gen_cs/mod.rs
@@ -398,7 +398,7 @@ impl CsCodeOracle {
             FfiType::RustBuffer(_) => "RustBuffer".to_string(),
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
             FfiType::Callback(_) => "IntPtr".to_string(),
-            FfiType::Reference(typ) => format!("ref {}", self.ffi_type_label(typ, prefix_struct)),
+            FfiType::Reference(typ) => format!("IntPtr /*{}*/", self.ffi_type_label(typ, prefix_struct)),
             FfiType::RustCallStatus => "UniffiRustCallStatus".to_string(),
             FfiType::Struct(name) => {
                 if prefix_struct {


### PR DESCRIPTION
Passing vtable struct via 'ref' may cause invalid memory accesses when GC defragments the heap and may move the vtable struct address. To prevent GC from moving vtable struct, pin vtable struct using GCHandle.

To make the change work, update 'Reference' FFI type to use 'IntPtr' instead of 'ref'. Add some necessary casts from 'IntPtr' in callback implementation to make the code compile (the code previously used ref with concrete types).