### PR TITLE
Replace lock-based ConcurrentHandleMap with ConcurrentDictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ There are a few requirements depending on your target framework version.
         <TargetFramework>net461</TargetFramework>
         <LangVersion>10.0</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <PackageReference Include="IsExternalInit" Version="1.0.3"/>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="PolySharp" Version="1.15.0"/>
     </PropertyGroup>
     ```
 

--- a/dotnet-tests/UniffiCS/UniffiCS.csproj
+++ b/dotnet-tests/UniffiCS/UniffiCS.csproj
@@ -8,8 +8,8 @@
   <!-- Allow testing internals of generated code -->
   <ItemGroup>
     <InternalsVisibleTo Include="UniffiCS.BindingTests" />
-    <PackageReference Include="IsExternalInit" Version="1.0.3"/>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="PolySharp" Version="1.15.0"/>
   </ItemGroup>
   <ItemGroup Condition="'$(SKIP_FIXTURE_COPY)' != 'true' and $([MSBuild]::IsOsPlatform('Windows')) == 'true'">
     <Content Include="../../target/debug/uniffi_fixtures.dll">


### PR DESCRIPTION
## Summary

- Replace `Dictionary<ulong, T>` + `lock` with `ConcurrentDictionary<ulong, T>` + `Interlocked.Increment` for lock-free, thread-safe handle management
- Add `[NotNullWhen(true)]` annotations to `TryGet` and `Remove` to eliminate `#pragma warning disable 8601` suppressions
- Replace `IsExternalInit` NuGet package with [PolySharp](https://github.com/Sergio0694/PolySharp) 1.15.0 in the test project to provide both `IsExternalInit` and `NotNullWhenAttribute` polyfills for `net461` targets (generates nothing on `net8.0+`)

Fixes #159

## Changes

### `bindgen/templates/ConcurrentHandleMap.cs`
- `Dictionary` + `lock` → `ConcurrentDictionary` (lock-free reads and writes via fine-grained striped locking internally)
- `currentHandle++` under lock → `Interlocked.Increment` (single atomic CPU instruction, no kernel transition)
- `#pragma warning disable 8601` → `[NotNullWhen(true)] out T? result` (proper nullability annotations)
- Added `self.add_import()` calls for `System.Collections.Concurrent`, `System.Diagnostics.CodeAnalysis`, `System.Threading` co-located with the template

### `dotnet-tests/UniffiCS/UniffiCS.csproj`
- Removed `IsExternalInit` 1.0.3
- Added `PolySharp` 1.15.0 (source generator that auto-detects missing types per target framework; emits polyfills only for `net461`, nothing on `net8.0+`)

### `README.md`
- Updated `net461` integration instructions to reference `PolySharp` instead of `IsExternalInit`

## Compatibility

- `ConcurrentDictionary` — available on all targets including .NET Framework 4.6.1
- `Interlocked.Increment(ref long)` — available on all targets (note: `Interlocked.Add(ref ulong, ulong)` is .NET 9+ only, which is why `long` is used with a cast)
- `[NotNullWhen]` — natively available on .NET Core 3.0+; polyfilled by PolySharp on `net461`
- Handle semantics preserved: first handle is `1`, sequential increment by 1, matching existing behavior

## Build verification

Tested locally — builds successfully on both `net461` and `net9.0` with 0 errors.