### PR TITLE
feat: use LibraryImport instead of DllImport for .NET 8+ targets

### DIFF
--- a/bindgen/templates/wrapper.cs
+++ b/bindgen/templates/wrapper.cs
@@ -23,6 +23,7 @@
 {{- self.add_import("System.Collections.Generic") }}
 {{- self.add_import("System.IO") }}
 {{- self.add_import("System.Linq") }}
+{{- self.add_import("System.Runtime.CompilerServices") }}
 {{- self.add_import("System.Runtime.InteropServices") }}
 
 {%- for imported_class in self.imports() %}


### PR DESCRIPTION
Closes #155


`[LibraryImport]` (introduced in .NET 7, recommended from .NET 8 LTS onward) provides:

| Aspect | `DllImport` | `LibraryImport` |
|---|---|---|
| **Native AOT** | Requires workarounds, breaks with trimming | Fully compatible |
| **Performance** | Runtime IL stub generation | Zero runtime overhead (source-generated) |
| **Validation** | Runtime marshalling errors | Compile-time errors |
| **Trimming** | Requires `DynamicDependency` annotations | Works out of the box |

Reference: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation

## Changes

### `bindgen/templates/NamespaceLibraryTemplate.cs`
- Class declaration uses `#if NET8_0_OR_GREATER` to conditionally add `partial`
- Each P/Invoke function declaration is wrapped in `#if`/`#else`/`#endif`:
  - .NET 8+: `[LibraryImport("lib")]` + `[UnmanagedCallConv]` + `public static partial`
  - Legacy: `[DllImport("lib", CallingConvention = CallingConvention.Cdecl)]` + `public static extern`

### `bindgen/templates/wrapper.cs`
- Added `System.Runtime.CompilerServices` import (provides `CallConvCdecl`)

## Why bool marshalling is not a concern

Booleans are converted to `sbyte` (Int8) at the FFI boundary by the FfiConverter layer, so `LibraryImport`'s different default bool marshalling does not apply.

## Example generated output

```csharp
    // ...

#if NET8_0_OR_GREATER
    [LibraryImport("uniffi_fixtures")]
    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
    public static partial ulong uniffi_arithmetical_fn_func_add(
        ulong @a, ulong @b, ref UniffiRustCallStatus _uniffi_out_err
    );
#else
    [DllImport("uniffi_fixtures", CallingConvention = CallingConvention.Cdecl)]
    public static extern ulong uniffi_arithmetical_fn_func_add(
        ulong @a, ulong @b, ref UniffiRustCallStatus _uniffi_out_err
    );
#endif
}
```
