### PR TITLE
Fix async callback interface return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "issue-165"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "thiserror 1.0.69",
+ "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "issue-28"
 version = "0.1.0"
 dependencies = [
@@ -1245,6 +1255,7 @@ version = "0.1.0"
 dependencies = [
  "global-methods-class-name",
  "issue-110",
+ "issue-165",
  "issue-28",
  "issue-60",
  "issue-75",

--- a/bindgen/templates/CallbackInterfaceTemplate.cs
+++ b/bindgen/templates/CallbackInterfaceTemplate.cs
@@ -17,12 +17,7 @@
     {%- for meth in cbi.methods() %}
     {%- call cs::docstring(meth, 4) %}
     {%- call cs::method_throws_annotation(meth.throws_type()) %}
-    {%- match meth.return_type() %}
-    {%- when Some with (return_type) %}
-    {{ return_type|type_name(ci) }} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %});
-    {%- else %}
-    void {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %});
-    {%- endmatch %}
+    {% call cs::return_type(meth) %} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %});
     {%- endfor %}
 }
 

--- a/dotnet-tests/UniffiCS.BindingTests/TestAsyncCallbackInterface.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestAsyncCallbackInterface.cs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System.Threading.Tasks;
+using uniffi.issue_165;
+
+namespace UniffiCS.BindingTests;
+
+class CSharpAsyncCallback : AsyncCallback
+{
+    public async Task<string> DoAsync(string @value)
+    {
+        await Task.Delay(1);
+        return @value.ToUpper();
+    }
+
+    public async Task DoAsyncVoid(string @value)
+    {
+        await Task.Delay(1);
+    }
+
+    public async Task<string> DoAsyncThrows(string @value)
+    {
+        await Task.Delay(1);
+        if (@value == "throw")
+        {
+            throw new AsyncCallbackException.Unexpected();
+        }
+        return @value.ToUpper();
+    }
+
+    public async Task DoAsyncVoidThrows(string @value)
+    {
+        await Task.Delay(1);
+        if (@value == "throw")
+        {
+            throw new AsyncCallbackException.Unexpected();
+        }
+    }
+}
+
+public class TestAsyncCallbackInterface
+{
+    [Fact]
+    public async Task TestAsyncReturn()
+    {
+        var callback = new CSharpAsyncCallback();
+        var result = await Issue165Methods.CallDoAsync(callback, "hello");
+        Assert.Equal("HELLO", result);
+    }
+
+    [Fact]
+    public async Task TestAsyncVoid()
+    {
+        var callback = new CSharpAsyncCallback();
+        await Issue165Methods.CallDoAsyncVoid(callback, "hello");
+    }
+
+    [Fact]
+    public async Task TestAsyncThrows()
+    {
+        var callback = new CSharpAsyncCallback();
+        var result = await Issue165Methods.CallDoAsyncThrows(callback, "hello");
+        Assert.Equal("HELLO", result);
+
+        await Assert.ThrowsAsync<AsyncCallbackException.Unexpected>(
+            () => Issue165Methods.CallDoAsyncThrows(callback, "throw")
+        );
+    }
+
+    [Fact]
+    public async Task TestAsyncVoidThrows()
+    {
+        var callback = new CSharpAsyncCallback();
+        await Issue165Methods.CallDoAsyncVoidThrows(callback, "hello");
+
+        await Assert.ThrowsAsync<AsyncCallbackException.Unexpected>(
+            () => Issue165Methods.CallDoAsyncVoidThrows(callback, "throw")
+        );
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -15,6 +15,7 @@ issue-60 = { path = "regressions/issue-60" }
 issue-75 = { path = "regressions/issue-75" }
 issue-76 = { path = "regressions/issue-76" }
 issue-110 = { path = "regressions/issue-110" }
+issue-165 = { path = "regressions/issue-165" }
 null-to-empty-string = { path = "null-to-empty-string" }
 uniffi-cs-custom-types-builtin = { path = "custom-types-builtin" }
 uniffi-cs-disposable-fixture = { path = "disposable" }

--- a/fixtures/regressions/issue-165/Cargo.toml
+++ b/fixtures/regressions/issue-165/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "issue-165"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "issue_165"
+
+[dependencies]
+async-trait = "0.1"
+thiserror = "1.0"
+uniffi = { workspace = true, features = ["build"] }
+uniffi_macros.workspace = true
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/issue-165/src/lib.rs
+++ b/fixtures/regressions/issue-165/src/lib.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum AsyncCallbackError {
+    #[error("Unexpected")]
+    Unexpected,
+}
+
+#[uniffi::export(callback_interface)]
+#[async_trait::async_trait]
+pub trait AsyncCallback: Send + Sync {
+    async fn do_async(&self, value: String) -> String;
+    async fn do_async_void(&self, value: String);
+    async fn do_async_throws(&self, value: String) -> Result<String, AsyncCallbackError>;
+    async fn do_async_void_throws(&self, value: String) -> Result<(), AsyncCallbackError>;
+}
+
+#[uniffi::export]
+pub async fn call_do_async(callback: Box<dyn AsyncCallback>, value: String) -> String {
+    callback.do_async(value).await
+}
+
+#[uniffi::export]
+pub async fn call_do_async_void(callback: Box<dyn AsyncCallback>, value: String) {
+    callback.do_async_void(value).await
+}
+
+#[uniffi::export]
+pub async fn call_do_async_throws(
+    callback: Box<dyn AsyncCallback>,
+    value: String,
+) -> Result<String, AsyncCallbackError> {
+    callback.do_async_throws(value).await
+}
+
+#[uniffi::export]
+pub async fn call_do_async_void_throws(
+    callback: Box<dyn AsyncCallback>,
+    value: String,
+) -> Result<(), AsyncCallbackError> {
+    callback.do_async_void_throws(value).await
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -32,4 +32,5 @@ mod uniffi_fixtures {
     issue_75::uniffi_reexport_scaffolding!();
     issue_76::uniffi_reexport_scaffolding!();
     issue_110::uniffi_reexport_scaffolding!();
+    issue_165::uniffi_reexport_scaffolding!();
 }


### PR DESCRIPTION
CallbackInterfaceTemplate.cs generated sync return types (e.g., `string`)
instead of `Task<T>` for async callback interface methods. Replace the
manual return type matching with the `cs::return_type(meth)` macro already
used by ObjectTemplate.cs.

Adds regression test fixture (issue-165) and C# tests.

Fixes #165