### PR TITLE
Upgrade to UniFFI 0.30 and close C# parity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-### UNRELEASED
+### v0.11.0+v0.30.0
+- TODO fill in
 
 ### v0.10.0+v0.29.4
 - **BREAKING** Upgrade to [uniFFI 0.29.4](https://mozilla.github.io/uniffi-rs/latest/Upgrading.html) [#124](https://github.com/NordSecurity/uniffi-bindgen-cs/issues/124)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "csharp-gap-fixes"
+version = "0.1.0"
+dependencies = [
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,15 +1179,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
@@ -1282,7 +1281,7 @@ dependencies = [
  "serde",
  "serde_json",
  "textwrap",
- "toml 0.5.11",
+ "toml",
  "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,6 +1291,7 @@ dependencies = [
 name = "uniffi-bindgen-cs-fixtures"
 version = "0.1.0"
 dependencies = [
+ "csharp-gap-fixes",
  "global-methods-class-name",
  "issue-110",
  "issue-28",
@@ -1529,7 +1529,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.5",
+ "toml",
  "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1555,7 +1555,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.5",
+ "toml",
  "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
@@ -1645,7 +1645,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.104",
- "toml 0.9.5",
+ "toml",
  "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1661,7 +1661,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.104",
- "toml 0.9.5",
+ "toml",
  "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,8 +460,8 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -633,6 +633,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -650,16 +651,16 @@ dependencies = [
 name = "issue-110"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "issue-28"
 version = "0.1.0"
 dependencies = [
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,8 +668,8 @@ name = "issue-60"
 version = "1.0.0"
 dependencies = [
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -677,8 +678,8 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -686,8 +687,8 @@ name = "issue-76"
 version = "1.0.0"
 dependencies = [
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -768,8 +769,8 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -982,6 +983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1179,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,38 +1237,38 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "uniffi"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d968cb62160c11f2573e6be724ef8b1b18a277aededd17033f8a912d73e2b4"
+checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "uniffi_bindgen 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_core 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
  "clap 4.5.42",
- "uniffi_bindgen 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_build 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_core 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_macros 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_pipeline 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_build 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_core 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-bindgen-cs"
-version = "0.10.0+v0.29.4"
+version = "0.11.0+v0.30.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1233,10 +1282,10 @@ dependencies = [
  "serde",
  "serde_json",
  "textwrap",
- "toml",
- "uniffi_bindgen 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.11",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1279,8 +1328,8 @@ dependencies = [
  "once_cell",
  "paste",
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1289,24 +1338,24 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-cs-optional-parameters-fixture"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-cs-positional-enums"
 version = "0.1.0"
 dependencies = [
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1314,158 +1363,158 @@ name = "uniffi-cs-stringify"
 version = "1.0.0"
 dependencies = [
  "paste",
- "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-example-arithmetic"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "url",
 ]
 
 [[package]]
 name = "uniffi-example-geometry"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-rondpoint"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-sprites"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-todolist"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-traits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-coverall"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-docstring"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-error-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "async-trait",
  "futures",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "chrono",
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-trait-methods"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "thiserror 2.0.12",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b39ef1acbe1467d5d210f274fae344cb6f8766339330cb4c9688752899bf6b"
+checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
  "askama",
@@ -1480,18 +1529,18 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml",
- "uniffi_internal_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.9.5",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
- "uniffi_udl 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "askama",
@@ -1506,39 +1555,39 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml",
- "uniffi_internal_macros 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_meta 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_pipeline 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_udl 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "toml 0.9.5",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_udl 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6683e6b665423cddeacd89a3f97312cf400b2fb245a26f197adaf65c45d505b2"
+checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d990b553d6b9a7ee9c3ae71134674739913d52350b56152b0e613595bb5a6f"
+checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1548,8 +1597,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1560,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f4f224becf14885c10e6e400b95cc4d1985738140cb194ccc2044563f8a56b"
+checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -1573,8 +1622,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -1585,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b481d385af334871d70904e6a5f129be7cd38c18fcf8dd8fd1f646b426a56d58"
+checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
 dependencies = [
  "camino",
  "fs-err",
@@ -1596,14 +1645,14 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.104",
- "toml",
- "uniffi_meta 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.9.5",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "camino",
  "fs-err",
@@ -1612,63 +1661,63 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.104",
- "toml",
- "uniffi_meta 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "toml 0.9.5",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f817868a3b171bb7bf259e882138d104deafde65684689b4694c846d322491"
+checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "uniffi_pipeline 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
+checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.10.0",
  "tempfile",
- "uniffi_internal_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.10.0",
  "tempfile",
- "uniffi_internal_macros 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5e9befada8a7069066191beb8865cdb8287f66e9041fb0bbffc8dfc5bea6b7"
+checksum = "a4adb08eb5589849231dc0626ba0f9a1297925fd751f0740fc630ae934dd9c5e"
 dependencies = [
  "anyhow",
  "camino",
@@ -1679,25 +1728,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
+checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.4"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.29.4 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
- "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4)",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
@@ -1750,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.4#00cd7e313cf73c78637161831ff17f8f53f7b824"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ members = [
 ]
 
 [workspace.dependencies]
-uniffi = { version = "0.29.4", features = ["build"] }
-uniffi_testing = "0.29.4"
-uniffi_macros = "0.29.4"
-uniffi_build = { version = "0.29.4", features=["builtin-bindgen"] }
-uniffi_bindgen = "0.29.4"
-uniffi_meta = "0.29.4"
-uniffi_udl = "0.29.4"
+uniffi = { version = "0.30.0", features = ["build"] }
+uniffi_testing = "0.30.0"
+uniffi_macros = "0.30.0"
+uniffi_build = { version = "0.30.0", features=["builtin-bindgen"] }
+uniffi_bindgen = "0.30.0"
+uniffi_meta = "0.30.0"
+uniffi_udl = "0.30.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minimum Rust version required to install `uniffi-bindgen-cs` is `1.88`.
 Newer Rust versions should also work fine.
 
 ```bash
-cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.10.0+v0.29.4
+cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.11.0+v0.30.0
 ```
 
 # How to generate bindings
@@ -89,6 +89,7 @@ The table shows `uniffi-rs` version history for tags that were published before 
 
 | uniffi-bindgen-cs version                 | uniffi-rs version                                |
 |-------------------------------------------|--------------------------------------------------|
+| v0.11.0                                   | v0.30.0                                          |
 | v0.10.0                                   | v0.29.4                                          |
 | v0.9.0                                    | v0.28.3                                          |
 | v0.6.0                                    | v0.25.0                                          |

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-cs"
-version = "0.10.0+v0.29.4"
+version = "0.11.0+v0.30.0"
 edition = "2021"
 
 [lib]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -24,7 +24,7 @@ paste = "1.0"
 serde = "1"
 serde_json = "1.0.0"
 textwrap = "0.16"
-toml = "0.5"
+toml = "0.9"
 
 uniffi_bindgen.workspace = true
 uniffi_meta.workspace = true

--- a/bindgen/src/gen_cs/callback_interface.rs
+++ b/bindgen/src/gen_cs/callback_interface.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 #[derive(Debug)]
 pub struct CallbackInterfaceCodeType {

--- a/bindgen/src/gen_cs/compounds.rs
+++ b/bindgen/src/gen_cs/compounds.rs
@@ -5,14 +5,20 @@
 use super::CodeType;
 use paste::paste;
 use uniffi_bindgen::{
-    backend::{Literal, Type},
+    interface::{DefaultValue, Literal, Type},
     ComponentInterface,
 };
 
 fn render_literal(literal: &Literal, inner: &Type, ci: &ComponentInterface) -> String {
     match literal {
         Literal::None => "null".into(),
-        Literal::Some { inner: meta } => super::CsCodeOracle.find(inner).literal(meta, ci),
+        Literal::Some { inner: meta } => {
+            // In UniFFI 0.30, meta is Box<DefaultValue>
+            match meta.as_ref() {
+                DefaultValue::Literal(lit) => super::CsCodeOracle.find(inner).literal(lit, ci),
+                DefaultValue::Default => "default".into(),
+            }
+        }
 
         // details/1-empty-list-as-default-method-parameter.md
         Literal::EmptySequence => "null".into(),

--- a/bindgen/src/gen_cs/custom.rs
+++ b/bindgen/src/gen_cs/custom.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 #[derive(Debug)]
 pub struct CustomCodeType {

--- a/bindgen/src/gen_cs/enum_.rs
+++ b/bindgen/src/gen_cs/enum_.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 #[derive(Debug)]
 pub struct EnumCodeType {

--- a/bindgen/src/gen_cs/external.rs
+++ b/bindgen/src/gen_cs/external.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 #[derive(Debug)]
 pub struct ExternalCodeType {

--- a/bindgen/src/gen_cs/filters.rs
+++ b/bindgen/src/gen_cs/filters.rs
@@ -122,7 +122,8 @@ pub(super) fn method_name(nm: &str, class_name: &str) -> Result<String, askama::
     let method_name = oracle().fn_name(nm);
     // In C#, a member cannot have the same name as its enclosing type (CS0542)
     if method_name == class_name {
-        Ok(format!("{}Method", method_name))
+        // Use a suffix that avoids clashing with user-defined `*_method` members.
+        Ok(format!("{}ClassMethod", method_name))
     } else {
         Ok(method_name)
     }
@@ -210,12 +211,18 @@ pub(super) fn or_pos_var(nm: &str, pos: &usize) -> Result<String, askama::Error>
 }
 
 /// Generate correct C# array creation expression for jagged arrays
-/// byte[] -> new byte[length][] (not new byte[][length])
+/// byte[] -> new byte[length][]
+/// byte[][] -> new byte[length][][]
 pub(super) fn array_new_expr(inner_type_name: &str) -> Result<String, askama::Error> {
-    if inner_type_name.ends_with("[]") {
-        // For jagged arrays like byte[], insert length before the trailing []
-        let base = &inner_type_name[..inner_type_name.len() - 2];
-        Ok(format!("new {base}[length][]"))
+    let mut base = inner_type_name;
+    let mut dimensions = 0usize;
+    while let Some(stripped) = base.strip_suffix("[]") {
+        base = stripped;
+        dimensions += 1;
+    }
+
+    if dimensions > 0 {
+        Ok(format!("new {base}[length]{}", "[]".repeat(dimensions)))
     } else {
         Ok(format!("new {inner_type_name}[length]"))
     }

--- a/bindgen/src/gen_cs/filters.rs
+++ b/bindgen/src/gen_cs/filters.rs
@@ -117,6 +117,17 @@ pub(super) fn fn_name(nm: &str) -> Result<String, askama::Error> {
     Ok(oracle().fn_name(nm))
 }
 
+/// Get the idiomatic C# rendering of a method name, checking for conflicts with class name.
+pub(super) fn method_name(nm: &str, class_name: &str) -> Result<String, askama::Error> {
+    let method_name = oracle().fn_name(nm);
+    // In C#, a member cannot have the same name as its enclosing type (CS0542)
+    if method_name == class_name {
+        Ok(format!("{}Method", method_name))
+    } else {
+        Ok(method_name)
+    }
+}
+
 /// Get the idiomatic C# rendering of a variable name.
 pub(super) fn var_name(nm: impl AsRef<str>) -> Result<String, askama::Error> {
     Ok(oracle().var_name(nm.as_ref()))
@@ -195,5 +206,17 @@ pub(super) fn or_pos_var(nm: &str, pos: &usize) -> Result<String, askama::Error>
         Ok(format!("v{pos}"))
     } else {
         Ok(nm.to_string())
+    }
+}
+
+/// Generate correct C# array creation expression for jagged arrays
+/// byte[] -> new byte[length][] (not new byte[][length])
+pub(super) fn array_new_expr(inner_type_name: &str) -> Result<String, askama::Error> {
+    if inner_type_name.ends_with("[]") {
+        // For jagged arrays like byte[], insert length before the trailing []
+        let base = &inner_type_name[..inner_type_name.len() - 2];
+        Ok(format!("new {base}[length][]"))
+    } else {
+        Ok(format!("new {inner_type_name}[length]"))
     }
 }

--- a/bindgen/src/gen_cs/miscellany.rs
+++ b/bindgen/src/gen_cs/miscellany.rs
@@ -4,7 +4,7 @@
 
 use super::CodeType;
 use paste::paste;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 macro_rules! impl_code_type_for_miscellany {
     ($T:ty, $class_name:literal, $canonical_name:literal) => {

--- a/bindgen/src/gen_cs/mod.rs
+++ b/bindgen/src/gen_cs/mod.rs
@@ -12,8 +12,9 @@ use askama::Template;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 
-use uniffi_bindgen::backend::Type;
+use uniffi_bindgen::interface::Type;
 use uniffi_bindgen::interface::*;
+use uniffi_meta::DefaultValueMetadata;
 use uniffi_bindgen::ComponentInterface;
 
 mod callback_interface;
@@ -389,7 +390,7 @@ impl CsCodeOracle {
             FfiType::UInt8 => "byte".to_string(),
             FfiType::Float32 => "float".to_string(),
             FfiType::Float64 => "double".to_string(),
-            FfiType::RustArcPtr(_) => "IntPtr".to_string(),
+            // RustArcPtr removed in UniFFI 0.30 - using Handle instead
             FfiType::RustBuffer(_) => "RustBuffer".to_string(),
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
             FfiType::Callback(_) => "IntPtr".to_string(),

--- a/bindgen/src/gen_cs/object.rs
+++ b/bindgen/src/gen_cs/object.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, interface::ObjectImpl, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, interface::ObjectImpl, ComponentInterface};
 
 #[derive(Debug)]
 pub struct ObjectCodeType {

--- a/bindgen/src/gen_cs/primitives.rs
+++ b/bindgen/src/gen_cs/primitives.rs
@@ -5,7 +5,7 @@
 use super::CodeType;
 use paste::paste;
 use uniffi_bindgen::interface::{Radix, Type};
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 fn render_literal(literal: &Literal) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {

--- a/bindgen/src/gen_cs/record.rs
+++ b/bindgen/src/gen_cs/record.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 #[derive(Debug)]
 pub struct RecordCodeType {

--- a/bindgen/templates/Async.cs
+++ b/bindgen/templates/Async.cs
@@ -31,9 +31,9 @@ internal static class _UniFFIAsync {
         }
     }
 
-    public class UniffiForeignFutureFreeCallback
+    public class UniffiForeignFutureDroppedCallback
     {
-        public static _UniFFILib.UniffiForeignFutureFree callback = Callback;
+        public static _UniFFILib.UniffiForeignFutureDroppedCallback callback = Callback;
 
         public static void Callback(ulong handle)
         {

--- a/bindgen/templates/CallbackInterfaceImpl.cs
+++ b/bindgen/templates/CallbackInterfaceImpl.cs
@@ -113,8 +113,8 @@ class {{ callback_impl_name }} {
 
             var foreignHandle = _UniFFIAsync._foreign_futures_map.Insert(cts);
             unsafe {
-                (*(_UniFFILib.UniffiForeignFuture*)uniffiOutReturn).handle = foreignHandle;
-                (*(_UniFFILib.UniffiForeignFuture*)uniffiOutReturn).dropped = Marshal.GetFunctionPointerForDelegate(_UniFFIAsync.UniffiForeignFutureDroppedCallback.callback);;
+                (*(_UniFFILib.UniffiForeignFutureDroppedCallbackStruct*)uniffiOutDroppedCallback).handle = foreignHandle;
+                (*(_UniFFILib.UniffiForeignFutureDroppedCallbackStruct*)uniffiOutDroppedCallback).free = Marshal.GetFunctionPointerForDelegate(_UniFFIAsync.UniffiForeignFutureDroppedCallback.callback);
             }
             {%- endif %}
         } else {

--- a/bindgen/templates/CallbackInterfaceImpl.cs
+++ b/bindgen/templates/CallbackInterfaceImpl.cs
@@ -114,7 +114,7 @@ class {{ callback_impl_name }} {
             var foreignHandle = _UniFFIAsync._foreign_futures_map.Insert(cts);
             unsafe {
                 (*(_UniFFILib.UniffiForeignFuture*)uniffiOutReturn).handle = foreignHandle;
-                (*(_UniFFILib.UniffiForeignFuture*)uniffiOutReturn).free = Marshal.GetFunctionPointerForDelegate(_UniFFIAsync.UniffiForeignFutureFreeCallback.callback);;
+                (*(_UniFFILib.UniffiForeignFuture*)uniffiOutReturn).dropped = Marshal.GetFunctionPointerForDelegate(_UniFFIAsync.UniffiForeignFutureDroppedCallback.callback);;
             }
             {%- endif %}
         } else {

--- a/bindgen/templates/ConcurrentHandleMap.cs
+++ b/bindgen/templates/ConcurrentHandleMap.cs
@@ -2,13 +2,17 @@ class ConcurrentHandleMap<T> where T: notnull {
     Dictionary<ulong, T> map = new Dictionary<ulong, T>();
 
     Object lock_ = new Object();
-    ulong currentHandle = 0;
+    // Foreign handles must be odd so the Rust side can distinguish them from Rust-owned pointers.
+    // See: https://mozilla.github.io/uniffi-rs/latest/internals/object_references.html
+    ulong currentHandle = 1;
 
     public ulong Insert(T obj) {
         lock (lock_) {
-            currentHandle += 1;
-            map[currentHandle] = obj;
-            return currentHandle;
+            var handle = currentHandle;
+            // Increment by 2 to keep handles odd.
+            currentHandle += 2;
+            map[handle] = obj;
+            return handle;
         }
     }
 

--- a/bindgen/templates/NamespaceLibraryTemplate.cs
+++ b/bindgen/templates/NamespaceLibraryTemplate.cs
@@ -2,6 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
 
+{%- macro callback_arg_list(callback) %}
+    {%- match callback.return_type() %}
+    {%- when Some with (_type) %}
+    {# Method returns a value - include all args including uniffiOutReturn #}
+    {%- for arg in callback.arguments() %}
+    {%- if !loop.first %}, {% endif %}{{ arg.type_().borrow()|ffi_type_name }} {{ arg.name()|var_name }}
+    {%- endfor %}
+    {%- when None %}
+    {# Void method - filter out uniffiOutReturn #}
+    {%- for arg in callback.arguments() %}
+    {%- if arg.name() != "uniffiOutReturn" %}
+    {%- if !loop.first %}, {% endif %}{{ arg.type_().borrow()|ffi_type_name }} {{ arg.name()|var_name }}
+    {%- endif %}
+    {%- endfor %}
+    {%- endmatch %}
+    {%- if callback.has_rust_call_status_arg() %}{% if callback.arguments().len() > 0 %}, {% endif %}ref UniffiRustCallStatus _uniffi_out_err{% endif %}
+{%- endmacro %}
+
 // This is an implementation detail that will be called internally by the public API.
 static class _UniFFILib {
     {%- for def in ci.ffi_definitions() %}
@@ -9,7 +27,7 @@ static class _UniFFILib {
     {%- when FfiDefinition::CallbackFunction(callback) %}
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate {% call cs::ffi_return_type(callback) %} {{ callback.name()|ffi_callback_name }}(
-        {% call cs::arg_list_ffi_decl(callback) %}
+        {% call callback_arg_list(callback) %}
     );
     {%- when FfiDefinition::Struct(ffi_struct) %}
     [StructLayout(LayoutKind.Sequential)]

--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -19,7 +19,7 @@
     {%- for meth in obj.methods() %}
     {%- call cs::docstring(meth, 4) %}
     {%- call cs::method_throws_annotation(meth.throws_type()) %}
-    {%  call cs::return_type(meth) %} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %});
+    {%  call cs::return_type(meth) %} {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %});
     {%- endfor %}
 }
 
@@ -130,7 +130,7 @@
     {%- call cs::docstring(meth, 4) %}
     {%- call cs::method_throws_annotation(meth.throws_type()) %}
     {%- if meth.is_async() %}
-    public async {% call cs::return_type(meth) %} {{ meth.name()|fn_name }}({%- call cs::arg_list_decl(meth) -%}) {
+    public async {% call cs::return_type(meth) %} {{ meth.name()|method_name(impl_name) }}({%- call cs::arg_list_decl(meth) -%}) {
         {%- call cs::async_call(meth, true) %}
     }
     {%- else %}
@@ -138,17 +138,17 @@
     {%- match meth.return_type() -%}
     {%- when Some with (return_type) %}
     {%- if meth.name() == "Message" %}
-    public new {{ return_type|type_name(ci) }} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %}) {
+    public new {{ return_type|type_name(ci) }} {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %}) {
         return CallWithPointer(thisPtr => {{ return_type|lift_fn }}({%- call cs::to_ffi_call_with_prefix("thisPtr", meth) %}));
     }
     {%- else %}
-    public {{ return_type|type_name(ci) }} {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %}) {
+    public {{ return_type|type_name(ci) }} {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %}) {
         return CallWithPointer(thisPtr => {{ return_type|lift_fn }}({%- call cs::to_ffi_call_with_prefix("thisPtr", meth) %}));
     }
     {%- endif %}
 
     {%- when None %}
-    public void {{ meth.name()|fn_name }}({% call cs::arg_list_decl(meth) %}) {
+    public void {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %}) {
         CallWithPointer(thisPtr => {%- call cs::to_ffi_call_with_prefix("thisPtr", meth) %});
     }
     {% endmatch %}

--- a/bindgen/templates/RecordTemplate.cs
+++ b/bindgen/templates/RecordTemplate.cs
@@ -31,7 +31,11 @@
     {%- call cs::docstring(field, 4) %}
     {{ field|type_name(ci) }} {{ field.name()|var_name -}}
     {%- match field.default_value() %}
-        {%- when Some with(literal) %} = {{ literal|render_literal(field, ci) }}
+        {%- when Some with(defval) %}
+            {%- match defval %}
+            {%- when DefaultValueMetadata::Literal with(literal) %} = {{ literal|render_literal(field, ci) }}
+            {%- when DefaultValueMetadata::Default %} = default
+            {%- endmatch %}
         {%- else %}
     {%- endmatch -%}
     {% if !loop.last %}, {% endif %}

--- a/bindgen/templates/SequenceTemplate.cs
+++ b/bindgen/templates/SequenceTemplate.cs
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
 
 {%- let inner_type_name = inner_type|type_name(ci) %}
+{# Handle jagged arrays: byte[] -> byte[length][], not byte[][length] #}
+{%- let array_new_expr = inner_type_name|array_new_expr %}
 
 class {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}[]> {
     public static {{ ffi_converter_name }} INSTANCE = new {{ ffi_converter_name }}();
@@ -10,10 +12,10 @@ class {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}[]> 
     public override {{ inner_type_name }}[]  Read(BigEndianStream stream) {
         var length = stream.ReadInt();
         if (length == 0) {
-            return [];
+            return Array.Empty<{{ inner_type_name }}>();
         }
 
-        var result = new {{ inner_type_name }}[(length)];
+        var result = {{ array_new_expr }};
         var readFn = {{ inner_type|read_fn }};
         for (int i = 0; i < length; i++) {
             result[i] = readFn(stream);

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -138,7 +138,8 @@
 {%- macro destroy_fields(member, prefix) %}
     FFIObjectUtil.DisposeAll(
         {%- for field in member.fields() %}
-            {{ prefix }}.{{ field.name()|var_name }}{% if !loop.last %},{% endif %}
+            {%- let field_name = field.name()|or_pos_var(loop.index)|var_name %}
+            {{ prefix }}.{{ field_name }}{% if !loop.last %},{% endif %}
         {%- endfor %});
 {%- endmacro -%}
 

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -58,8 +58,18 @@
         (IntPtr future, IntPtr continuation, IntPtr data) => _UniFFILib.{{ func.ffi_rust_future_poll(ci) }}(future, continuation, data),
         // Complete
         (IntPtr future, ref UniffiRustCallStatus status) => {
-            {%- if func.return_type().is_some() %}
-            return {% endif %}_UniFFILib.{{ func.ffi_rust_future_complete(ci) }}(future, ref status);
+            {%- match func.return_type() %}
+            {%- when Some(return_type) %}
+            {%- match return_type %}
+            {%- when Type::Object { .. } %}
+            // Objects are returned as u64 handles from the FFI, but Lift expects IntPtr
+            return (IntPtr)_UniFFILib.{{ func.ffi_rust_future_complete(ci) }}(future, ref status);
+            {%- else %}
+            return _UniFFILib.{{ func.ffi_rust_future_complete(ci) }}(future, ref status);
+            {%- endmatch %}
+            {%- else %}
+            _UniFFILib.{{ func.ffi_rust_future_complete(ci) }}(future, ref status);
+            {%- endmatch %}
         },
         // Free
         (IntPtr future) => _UniFFILib.{{ func.ffi_rust_future_free(ci) }}(future),

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -105,7 +105,11 @@
     {%- for arg in func.arguments() -%}
         {{ arg|type_name(ci) }} {{ arg.name()|var_name -}}
         {%- match arg.default_value() %}
-        {%- when Some with(literal) %} = {{ literal|render_literal(arg, ci) }}
+        {%- when Some with(defval) %}
+            {%- match defval %}
+            {%- when DefaultValue::Literal with(literal) %} = {{ literal|render_literal(arg, ci) }}
+            {%- when DefaultValue::Default %} = default
+            {%- endmatch %}
         {%- else %}
         {%- endmatch %}
         {%- if !loop.last %}, {% endif -%}

--- a/dotnet-tests/UniffiCS.BindingTests/TestCsharpGapFixes.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestCsharpGapFixes.cs
@@ -1,0 +1,24 @@
+using uniffi.csharp_gap_fixes;
+
+namespace UniffiCS.BindingTests;
+
+public class TestCsharpGapFixes
+{
+    [Fact]
+    public void MethodNameConflictsAndNestedJaggedArraysWork()
+    {
+        var monitor = new Monitor();
+        Assert.Equal("monitor", monitor.MonitorClassMethod());
+        Assert.Equal("monitor_method", monitor.MonitorMethod());
+
+        var nested = CsharpGapFixesMethods.NestedBytes();
+        Assert.Equal(2, nested.Length);
+
+        Assert.Equal(2, nested[0].Length);
+        Assert.Equal(new byte[] { 1, 2 }, nested[0][0]);
+        Assert.Equal(new byte[] { 3 }, nested[0][1]);
+
+        Assert.Single(nested[1]);
+        Assert.Equal(new byte[] { 4, 5, 6 }, nested[1][0]);
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -23,20 +23,20 @@ uniffi-cs-positional-enums = { path = "positional-enums" }
 uniffi-cs-stringify = { path = "stringify" }
 
 # Examples
-uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
+uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
 
 # Fixtures
-uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
-uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.4"}
+uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -15,6 +15,7 @@ issue-60 = { path = "regressions/issue-60" }
 issue-75 = { path = "regressions/issue-75" }
 issue-76 = { path = "regressions/issue-76" }
 issue-110 = { path = "regressions/issue-110" }
+csharp-gap-fixes = { path = "regressions/csharp-gap-fixes" }
 null-to-empty-string = { path = "null-to-empty-string" }
 uniffi-cs-custom-types-builtin = { path = "custom-types-builtin" }
 uniffi-cs-disposable-fixture = { path = "disposable" }

--- a/fixtures/regressions/csharp-gap-fixes/Cargo.toml
+++ b/fixtures/regressions/csharp-gap-fixes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "csharp-gap-fixes"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "csharp_gap_fixes"
+
+[dependencies]
+uniffi = { workspace = true, features = ["build"] }
+uniffi_macros.workspace = true
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/csharp-gap-fixes/README.md
+++ b/fixtures/regressions/csharp-gap-fixes/README.md
@@ -1,0 +1,6 @@
+# C# 0.30 gap-fix regressions
+
+This fixture guards two regressions:
+
+- Method name conflicts when an object method matches its class name.
+- Nested jagged array generation for `sequence<sequence<sequence<u8>>>`.

--- a/fixtures/regressions/csharp-gap-fixes/build.rs
+++ b/fixtures/regressions/csharp-gap-fixes/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::generate_scaffolding("src/csharp-gap-fixes.udl").unwrap();
+}

--- a/fixtures/regressions/csharp-gap-fixes/src/csharp-gap-fixes.udl
+++ b/fixtures/regressions/csharp-gap-fixes/src/csharp-gap-fixes.udl
@@ -1,0 +1,9 @@
+namespace csharp_gap_fixes {
+    sequence<sequence<sequence<u8>>> nested_bytes();
+};
+
+interface Monitor {
+    constructor();
+    string monitor();
+    string monitor_method();
+};

--- a/fixtures/regressions/csharp-gap-fixes/src/lib.rs
+++ b/fixtures/regressions/csharp-gap-fixes/src/lib.rs
@@ -1,0 +1,21 @@
+pub fn nested_bytes() -> Vec<Vec<Vec<u8>>> {
+    vec![vec![vec![1, 2], vec![3]], vec![vec![4, 5, 6]]]
+}
+
+pub struct Monitor {}
+
+impl Monitor {
+    fn new() -> Monitor {
+        Monitor {}
+    }
+
+    fn monitor(&self) -> String {
+        "monitor".to_string()
+    }
+
+    fn monitor_method(&self) -> String {
+        "monitor_method".to_string()
+    }
+}
+
+uniffi::include_scaffolding!("csharp-gap-fixes");

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -32,4 +32,5 @@ mod uniffi_fixtures {
     issue_75::uniffi_reexport_scaffolding!();
     issue_76::uniffi_reexport_scaffolding!();
     issue_110::uniffi_reexport_scaffolding!();
+    csharp_gap_fixes::uniffi_reexport_scaffolding!();
 }


### PR DESCRIPTION
This PR upgrades `uniffi-bindgen-cs` from UniFFI `0.29.4` to `0.30.0` and is necessary to keep uniffi-bindgen-cs usable for consumers who have already moved to UniFFI 0.30. It includes C# generator/template fixes needed for real-world consumers (including payjoin-ffi-style usage), plus some regression coverage.

- This PR intentionally includes both baseline 0.30 parity and hardening/regression fixes to keep the current branch state coherent.
- External types support is still out of scope for this PR.