### PR TITLE
Fix jagged array allocation syntax for nested sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "null-to-empty-string",
  "uniffi-cs-custom-types-builtin",
  "uniffi-cs-disposable-fixture",
+ "uniffi-cs-nested-sequences",
  "uniffi-cs-optional-parameters-fixture",
  "uniffi-cs-positional-enums",
  "uniffi-cs-stringify",
@@ -1289,6 +1290,14 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
+ "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uniffi-cs-nested-sequences"
+version = "1.0.0"
+dependencies = [
  "uniffi 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_macros 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/bindgen/src/gen_cs/filters.rs
+++ b/bindgen/src/gen_cs/filters.rs
@@ -189,6 +189,19 @@ pub(super) fn order_fields(fields: &[Field]) -> Result<(Vec<Field>, bool), askam
     Ok((fields, is_reordered))
 }
 
+/// Generate correct C# array allocation expression for sequences.
+/// Handles jagged arrays where the inner type name itself contains brackets.
+/// e.g., "byte[]" → "new byte[(length)][]" instead of invalid "new byte[][(length)]"
+pub(super) fn new_array_expr(inner_type_name: &str) -> Result<String, askama::Error> {
+    if let Some(bracket_pos) = inner_type_name.find("[]") {
+        let base = &inner_type_name[..bracket_pos];
+        let brackets = &inner_type_name[bracket_pos..];
+        Ok(format!("new {base}[(length)]{brackets}"))
+    } else {
+        Ok(format!("new {inner_type_name}[(length)]"))
+    }
+}
+
 /// If the name is empty create one based on position of the variable
 pub(super) fn or_pos_var(nm: &str, pos: &usize) -> Result<String, askama::Error> {
     if nm.is_empty() {

--- a/bindgen/templates/SequenceTemplate.cs
+++ b/bindgen/templates/SequenceTemplate.cs
@@ -13,7 +13,7 @@ class {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}[]> 
             return [];
         }
 
-        var result = new {{ inner_type_name }}[(length)];
+        var result = {{ inner_type_name|new_array_expr }};
         var readFn = {{ inner_type|read_fn }};
         for (int i = 0; i < length; i++) {
             result[i] = readFn(stream);

--- a/dotnet-tests/UniffiCS.BindingTests/TestNestedSequences.cs
+++ b/dotnet-tests/UniffiCS.BindingTests/TestNestedSequences.cs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using uniffi.nested_sequences;
+
+namespace UniffiCS.BindingTests;
+
+public class TestNestedSequences
+{
+    [Fact]
+    public void TestNestedBytes()
+    {
+        byte[][] input = [
+            [1, 2, 3],
+            [4, 5],
+            [],
+        ];
+        var result = NestedSequencesMethods.NestedBytes(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void TestNestedStrings()
+    {
+        string[][] input = [
+            ["hello", "world"],
+            ["foo"],
+            [],
+        ];
+        var result = NestedSequencesMethods.NestedStrings(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void TestEmptyNestedSequence()
+    {
+        byte[][] input = [];
+        var result = NestedSequencesMethods.NestedBytes(input);
+        Assert.Equal(input, result);
+    }
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -20,6 +20,7 @@ uniffi-cs-custom-types-builtin = { path = "custom-types-builtin" }
 uniffi-cs-disposable-fixture = { path = "disposable" }
 uniffi-cs-optional-parameters-fixture = { path = "optional-parameters" }
 uniffi-cs-positional-enums = { path = "positional-enums" }
+uniffi-cs-nested-sequences = { path = "nested-sequences" }
 uniffi-cs-stringify = { path = "stringify" }
 
 # Examples

--- a/fixtures/nested-sequences/Cargo.toml
+++ b/fixtures/nested-sequences/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uniffi-cs-nested-sequences"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "nested_sequences"
+
+[dependencies]
+uniffi = { workspace = true, features = ["build"] }
+uniffi_macros.workspace = true
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/nested-sequences/src/lib.rs
+++ b/fixtures/nested-sequences/src/lib.rs
@@ -1,0 +1,11 @@
+uniffi::setup_scaffolding!();
+
+#[uniffi::export]
+fn nested_bytes(input: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+    input
+}
+
+#[uniffi::export]
+fn nested_strings(input: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    input
+}

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -26,6 +26,7 @@ mod uniffi_fixtures {
     uniffi_cs_disposable::uniffi_reexport_scaffolding!();
     uniffi_cs_optional_parameters::uniffi_reexport_scaffolding!();
     uniffi_cs_positional_enums::uniffi_reexport_scaffolding!();
+    nested_sequences::uniffi_reexport_scaffolding!();
     stringify::uniffi_reexport_scaffolding!();
     issue_28::uniffi_reexport_scaffolding!();
     issue_60::uniffi_reexport_scaffolding!();


### PR DESCRIPTION
Closes #147 

When the inner type of a sequence is itself an array type (e.g., Vec<Vec<u8>> mapping to byte[][]), the template generated invalid C#: `new byte[][(length)]`. The correct syntax is `new byte[(length)][]`.

Adds a `new_array_expr` filter that finds the first `[]` in the type name and inserts the size specifier before the trailing brackets. This handles arbitrary nesting depths (e.g., byte[][][] for Vec<Vec<Vec<u8>>>).

Includes a test fixture with nested byte and string sequences.