### PR TITLE
Lift strings and byte arrays without intermediate copies on .NET 8+

### DIFF
--- a/bindgen/templates/BigEndianStream.cs
+++ b/bindgen/templates/BigEndianStream.cs
@@ -166,6 +166,23 @@ class BigEndianStream {
         return result;
     }
 
+    // Decodes a UTF-8 string of `length` bytes directly from the underlying
+    // unmanaged memory when possible, avoiding an intermediate byte[] copy.
+    public string ReadUtf8String(int length) {
+        stream.CheckRemaining(length);
+#if NET8_0_OR_GREATER
+        if (stream is UnmanagedMemoryStream unmanagedStream) {
+            unsafe {
+                var result = System.Text.Encoding.UTF8.GetString(
+                    new ReadOnlySpan<byte>(unmanagedStream.PositionPointer, length));
+                unmanagedStream.Position += length;
+                return result;
+            }
+        }
+#endif
+        return System.Text.Encoding.UTF8.GetString(ReadBytes(length));
+    }
+
     public byte ReadByte() => (byte)stream.ReadUint32(bytesToRead: 1);
     public ushort ReadUShort() => (ushort)stream.ReadUint32(bytesToRead: 2);
     public uint ReadUInt() => (uint)stream.ReadUint32(bytesToRead: 4);

--- a/bindgen/templates/BytesTemplate.cs
+++ b/bindgen/templates/BytesTemplate.cs
@@ -5,6 +5,24 @@
 class {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     public static {{ ffi_converter_name }} INSTANCE = new {{ ffi_converter_name }}();
 
+#if NET8_0_OR_GREATER
+    // Copy straight out of the RustBuffer, skipping the stream machinery.
+    public override {{ type_name }} Lift(RustBuffer value) {
+        try {
+            unsafe {
+                var buffer = new ReadOnlySpan<byte>((byte*)value.data, Convert.ToInt32(value.len));
+                var length = System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(buffer);
+                if (4 + length != buffer.Length) {
+                    throw new InternalException("junk remaining in buffer after lifting, something is very wrong!!");
+                }
+                return buffer.Slice(4, length).ToArray();
+            }
+        } finally {
+            RustBuffer.Free(value);
+        }
+    }
+#endif
+
     public override {{ type_name }} Read(BigEndianStream stream) {
         var length = stream.ReadInt();
         return stream.ReadBytes(length);

--- a/bindgen/templates/StringHelper.cs
+++ b/bindgen/templates/StringHelper.cs
@@ -10,8 +10,16 @@ class FfiConverterString: FfiConverter<string, RustBuffer> {
     // store our length and avoid writing it out to the buffer.
     public override string Lift(RustBuffer value) {
         try {
-            var bytes = value.AsStream().ReadBytes(Convert.ToInt32(value.len));
+            var length = Convert.ToInt32(value.len);
+#if NET8_0_OR_GREATER
+            unsafe {
+                return System.Text.Encoding.UTF8.GetString(
+                    new ReadOnlySpan<byte>((byte*)value.data, length));
+            }
+#else
+            var bytes = value.AsStream().ReadBytes(length);
             return System.Text.Encoding.UTF8.GetString(bytes);
+#endif
         } finally {
             RustBuffer.Free(value);
         }
@@ -19,8 +27,7 @@ class FfiConverterString: FfiConverter<string, RustBuffer> {
 
     public override string Read(BigEndianStream stream) {
         var length = stream.ReadInt();
-        var bytes = stream.ReadBytes(length);
-        return System.Text.Encoding.UTF8.GetString(bytes);
+        return stream.ReadUtf8String(length);
     }
 
     public override RustBuffer Lower(string value) {
@@ -31,10 +38,19 @@ class FfiConverterString: FfiConverter<string, RustBuffer> {
         }
         {%- when _ %}
         {%- endmatch %}
+#if NET8_0_OR_GREATER
+        var rbuf = RustBuffer.Alloc(System.Text.Encoding.UTF8.GetByteCount(value));
+        unsafe {
+            var dest = new Span<byte>((byte*)rbuf.data, Convert.ToInt32(rbuf.len));
+            System.Text.Encoding.UTF8.GetBytes(value, dest);
+        }
+        return rbuf;
+#else
         var bytes = System.Text.Encoding.UTF8.GetBytes(value);
         var rbuf = RustBuffer.Alloc(bytes.Length);
         rbuf.AsWriteableStream().WriteBytes(bytes);
         return rbuf;
+#endif
     }
 
     // TODO(CS)


### PR DESCRIPTION
## Problem

`FfiConverterString.Lift`/`Read` decode through `AsStream().ReadBytes(length)`, which
materializes a temporary managed `byte[]` copy of the native buffer before
`Encoding.UTF8.GetString` — once per lifted string, including every element of lists, maps
and records, and every string callback argument. `Lower` likewise allocates a temporary
array from `Encoding.UTF8.GetBytes` and copies it into the RustBuffer, and
`FfiConverterByteArray.Lift` routes a plain byte copy through the stream machinery.

## Change

All gated behind `#if NET8_0_OR_GREATER`; the `netstandard2.0` paths are unchanged.
No public API or behavior changes.

- `FfiConverterString.Lift`: decode straight from the RustBuffer memory via
  `Encoding.UTF8.GetString(ReadOnlySpan<byte>)`.
- `FfiConverterString.Read`: new `BigEndianStream.ReadUtf8String(length)` decodes in place
  at the `UnmanagedMemoryStream` position (falls back to the existing path otherwise).
- `FfiConverterString.Lower`: `Encoding.UTF8.GetBytes(string, Span<byte>)` directly into
  the RustBuffer allocation.
- `FfiConverterByteArray.Lift`: a single span copy out of the RustBuffer.

## Benchmarks

BenchmarkDotNet 0.15.2, .NET 8.0.28, Windows 11 x64 (Ryzen 9 7950X); mean per op and
managed allocations per op, `main` (e10ce41) vs this branch:

| Scenario | main | this PR |
|---|---|---|
| string argument, 1 KiB | 153 ns, 1.3 KB | 104 ns, 176 B |
| string argument, 1 MiB | 272 µs, 1.0 MB | 182 µs, 176 B |
| string return, 1 MiB | 687 µs, 3.0 MB | 309 µs, 2.0 MB |
| `string[]` (1000 × 16 B) return | 64 µs, 110 KB | 54 µs, 63 KB |
| string callback argument, ~200 B | 121 ns, 952 B | 83 ns, 616 B |
| `byte[]` return, 1 MiB | 1.10 ms | 0.98 ms |

String arguments no longer allocate managed memory proportional to the payload (the
remaining fixed 176 B is the `RustCall` closure — subject of a separate follow-up PR).

Harness: <https://github.com/yuyoyuppe/ffi-microbench> — a checksum-verified smoke gate
runs over every generated surface before timing, and a multi-threaded stress harness
(including non-ASCII payloads) passes with zero memory drift.

## Testing

- `./build.sh && ./generate_bindings.sh` + dotnet-tests: 158/159, identical to `main`
  (the one failure is the pre-existing `ObjectDecrementsReference` GC-timing flake; it
  passes in isolation on both branches).
- Both `UniffiCS` target frameworks compile (netstandard2.0 + net8.0).
