### PR TITLE
Emit sync calls without per-call closure allocations

### DIFF
--- a/bindgen/templates/Helpers.cs
+++ b/bindgen/templates/Helpers.cs
@@ -82,14 +82,12 @@ class _UniffiHelpers {
     public delegate void RustCallAction(ref UniffiRustCallStatus status);
     public delegate U RustCallFunc<out U>(ref UniffiRustCallStatus status);
 
-    // Call a rust function that returns a Result<>.  Pass in the Error class companion that corresponds to the Err
-    public static U RustCallWithError<U, E>(CallStatusErrorHandler<E> errorHandler, RustCallFunc<U> callback)
+    // Check the status of an already-completed rust call and throw on failure.
+    public static void CheckCallStatus<E>(CallStatusErrorHandler<E> errorHandler, ref UniffiRustCallStatus status)
         where E: System.Exception
     {
-        var status = new UniffiRustCallStatus();
-        var return_value = callback(ref status);
         if (status.IsSuccess()) {
-            return return_value;
+            return;
         } else if (status.IsError()) {
             throw errorHandler.Lift(status.error_buf);
         } else if (status.IsPanic()) {
@@ -104,6 +102,16 @@ class _UniffiHelpers {
         } else {
             throw new InternalException($"Unknown rust call status: {status.code}");
         }
+    }
+
+    // Call a rust function that returns a Result<>.  Pass in the Error class companion that corresponds to the Err
+    public static U RustCallWithError<U, E>(CallStatusErrorHandler<E> errorHandler, RustCallFunc<U> callback)
+        where E: System.Exception
+    {
+        var status = new UniffiRustCallStatus();
+        var return_value = callback(ref status);
+        CheckCallStatus(errorHandler, ref status);
+        return return_value;
     }
 
     // Call a rust function that returns a Result<>.  Pass in the Error class companion that corresponds to the Err

--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -52,15 +52,16 @@
     {%- endmatch %}
 
     protected void FreeRustArcPtr() {
-        _UniffiHelpers.RustCall((ref UniffiRustCallStatus status) => {
-            _UniFFILib.{{ obj.ffi_object_free().name() }}(this.pointer, ref status);
-        });
+        var status = new UniffiRustCallStatus();
+        _UniFFILib.{{ obj.ffi_object_free().name() }}(this.pointer, ref status);
+        _UniffiHelpers.CheckCallStatus(NullCallStatusErrorHandler.INSTANCE, ref status);
     }
 
     protected ulong CloneRustArcPtr() {
-        return _UniffiHelpers.RustCall((ref UniffiRustCallStatus status) => {
-            return _UniFFILib.{{ obj.ffi_object_clone().name() }}(this.pointer, ref status);
-        });
+        var status = new UniffiRustCallStatus();
+        var result = _UniFFILib.{{ obj.ffi_object_clone().name() }}(this.pointer, ref status);
+        _UniffiHelpers.CheckCallStatus(NullCallStatusErrorHandler.INSTANCE, ref status);
+        return result;
     }
 
     public void Destroy()
@@ -138,12 +139,25 @@
     {%- match meth.return_type() -%}
     {%- when Some with (return_type) %}
     public {% if is_error && meth.name()|method_name(impl_name) == "Message" %}new {% endif %}{{ return_type|type_name(ci) }} {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %}) {
-        return CallWithPointer(thisPtr => {{ return_type|lift_fn }}({%- call cs::to_ffi_call_with_prefix("thisPtr", meth) %}));
+        IncrementCallCounter();
+        try {
+            var _thisPtr = CloneRustArcPtr();
+            {%- call cs::ffi_call_binding(meth, "_thisPtr") %}
+            return {{ return_type|lift_fn }}(_uniffiResult);
+        } finally {
+            DecrementCallCounter();
+        }
     }
 
     {%- when None %}
     public {% if is_error && meth.name()|method_name(impl_name) == "Message" %}new {% endif %}void {{ meth.name()|method_name(impl_name) }}({% call cs::arg_list_decl(meth) %}) {
-        CallWithPointer(thisPtr => {%- call cs::to_ffi_call_with_prefix("thisPtr", meth) %});
+        IncrementCallCounter();
+        try {
+            var _thisPtr = CloneRustArcPtr();
+            {%- call cs::ffi_call_binding(meth, "_thisPtr") %}
+        } finally {
+            DecrementCallCounter();
+        }
     }
     {% endmatch %}
     {% endif %}

--- a/bindgen/templates/RustBufferTemplate.cs
+++ b/bindgen/templates/RustBufferTemplate.cs
@@ -13,19 +13,19 @@ internal struct RustBuffer {
     public IntPtr data;
 
     public static RustBuffer Alloc(int size) {
-        return _UniffiHelpers.RustCall((ref UniffiRustCallStatus status) => {
-            var buffer = _UniFFILib.{{ ci.ffi_rustbuffer_alloc().name() }}(Convert.ToUInt64(size), ref status);
-            if (buffer.data == IntPtr.Zero) {
-                throw new AllocationException($"RustBuffer.Alloc() returned null data pointer (size={size})");
-            }
-            return buffer;
-        });
+        var status = new UniffiRustCallStatus();
+        var buffer = _UniFFILib.{{ ci.ffi_rustbuffer_alloc().name() }}(Convert.ToUInt64(size), ref status);
+        _UniffiHelpers.CheckCallStatus(NullCallStatusErrorHandler.INSTANCE, ref status);
+        if (buffer.data == IntPtr.Zero) {
+            throw new AllocationException($"RustBuffer.Alloc() returned null data pointer (size={size})");
+        }
+        return buffer;
     }
 
     public static void Free(RustBuffer buffer) {
-        _UniffiHelpers.RustCall((ref UniffiRustCallStatus status) => {
-            _UniFFILib.{{ ci.ffi_rustbuffer_free().name() }}(buffer, ref status);
-        });
+        var status = new UniffiRustCallStatus();
+        _UniFFILib.{{ ci.ffi_rustbuffer_free().name() }}(buffer, ref status);
+        _UniffiHelpers.CheckCallStatus(NullCallStatusErrorHandler.INSTANCE, ref status);
     }
 
     public static BigEndianStream MemoryStream(IntPtr data, long length)

--- a/bindgen/templates/TopLevelFunctionTemplate.cs
+++ b/bindgen/templates/TopLevelFunctionTemplate.cs
@@ -5,7 +5,7 @@
 {%- call cs::docstring(func, 4) %}
 {%- call cs::method_throws_annotation(func.throws_type()) %}
 {%- if func.is_async() %}
-   public static async {% call cs::return_type(func) %} {{ func.name()|fn_name }}({%- call cs::arg_list_decl(func) -%}) 
+   public static async {% call cs::return_type(func) %} {{ func.name()|fn_name }}({%- call cs::arg_list_decl(func) -%})
    {
         {%- call cs::async_call(func, false) %}
    }
@@ -13,11 +13,12 @@
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
     public static {{ return_type|type_name(ci) }} {{ func.name()|fn_name }}({%- call cs::arg_list_decl(func) -%}) {
-        return {{ return_type|lift_fn }}({% call cs::to_ffi_call(func) %});
+        {%- call cs::ffi_call_binding(func, "") %}
+        return {{ return_type|lift_fn }}(_uniffiResult);
     }
 {% when None %}
     public static void {{ func.name()|fn_name }}({% call cs::arg_list_decl(func) %}) {
-        {% call cs::to_ffi_call(func) %};
+        {%- call cs::ffi_call_binding(func, "") %}
     }
 {% endmatch %}
 {% endif  %}

--- a/bindgen/templates/macros.cs
+++ b/bindgen/templates/macros.cs
@@ -8,6 +8,28 @@
 // passed to rust via `lower_arg_list`
 #}
 
+{#
+// Statement-form call into rust: declares `_status`, invokes the FFI function
+// (binding `_uniffiResult` when it returns a value), and checks the status.
+// Unlike to_ffi_call, this does not allocate a closure per call.
+// `prefix` is prepended to the argument list when non-empty (e.g. "_thisPtr").
+#}
+{%- macro ffi_call_binding(func, prefix) %}
+        var _status = new UniffiRustCallStatus();
+        {%- match func.return_type() %}
+        {%- when Some with (return_type) %}
+        var _uniffiResult = _UniFFILib.{{ func.ffi_func().name() }}({% if prefix != "" %}{{ prefix }}, {% endif %}{% call lower_arg_list(func) %}{% if func.arguments().len() > 0 %}, {% endif %}ref _status);
+        {%- when None %}
+        _UniFFILib.{{ func.ffi_func().name() }}({% if prefix != "" %}{{ prefix }}, {% endif %}{% call lower_arg_list(func) %}{% if func.arguments().len() > 0 %}, {% endif %}ref _status);
+        {%- endmatch %}
+        {%- match func.throws_type() %}
+        {%- when Some with (e) %}
+        _UniffiHelpers.CheckCallStatus({{ e|error_converter_name }}.INSTANCE, ref _status);
+        {%- else %}
+        _UniffiHelpers.CheckCallStatus(NullCallStatusErrorHandler.INSTANCE, ref _status);
+        {%- endmatch %}
+{%- endmacro -%}
+
 {%- macro to_ffi_call(func) -%}
     {%- match func.throws_type() %}
     {%- when Some with (e) %}


### PR DESCRIPTION
## Problem

Every generated sync call goes through `RustCall`/`RustCallWithError` with a lambda that
captures the lowered arguments — a closure + delegate allocation on every FFI call: 88 B
for a no-arg function, 248 B per object method once the `CallWithPointer` and
`CloneRustArcPtr` lambdas are counted. That is steady GC pressure on every call,
independent of payload size.

## Change

- Factor the status check out of `RustCallWithError` into `CheckCallStatus`
  (behavior unchanged).
- Add a statement-form `ffi_call_binding` template macro: the `UniffiRustCallStatus`
  struct stays on the stack, the FFI function is invoked directly, and the status is
  checked via `CheckCallStatus` — no delegate, no closure.
- Use it for top-level functions and object methods; inline the remaining closures in
  `CloneRustArcPtr`/`FreeRustArcPtr` and `RustBuffer.Alloc`/`Free`.
- Constructors (expression position in `: this(...)`), async calls, and uniffi-trait
  methods keep the existing helpers.

No public API changes; error and panic propagation is identical (same checks, same
exception types). The change is plain C# — both target frameworks benefit.

## Benchmarks

BenchmarkDotNet 0.15.2, .NET 8.0.28, Windows 11 x64 (Ryzen 9 7950X); mean per op and
managed allocations per op, `main` (e10ce41) vs this branch:

| Scenario | main | this PR |
|---|---|---|
| no-arg function call | 8.8 ns, 88 B | 5.5 ns, **0 B** |
| `fn add(u64, u64) -> u64` | 10.0 ns, 96 B | 5.9 ns, **0 B** |
| object method (`&self`, u64) | 29.6 ns, 248 B | 10.1 ns, **0 B** |
| `Result<(), E>` call, Ok path | 14.2 ns, 176 B | 6.9 ns, **0 B** |
| fire a registered callback once | 32.7 ns, 176 B | 25.1 ns, **0 B** |

Harness: <https://github.com/yuyoyuppe/ffi-microbench> (checksum-verified smoke gate,
multi-threaded stress harness — zero memory drift).

## Testing

- dotnet-tests on this branch in isolation: **159/159**.
- Both `UniffiCS` target frameworks compile (netstandard2.0 + net8.0).
