### PR TITLE
Fix object trait implementations in generated bindings

### DIFF
--- a/bindgen/templates/ObjectTemplate.cs
+++ b/bindgen/templates/ObjectTemplate.cs
@@ -24,7 +24,11 @@
 }
 
 {%- call cs::docstring(obj, 0) %}
-{{ config.access_modifier() }} class {{ impl_name }} : {% if is_error -%}UniffiException, {% endif -%}{{ interface_name }}, IDisposable {
+{{ config.access_modifier() }} class {{ impl_name }} : {% if is_error -%}UniffiException, {% endif -%}{{ interface_name }}
+    {%- for trait_impl in obj.trait_impls() -%}
+    , {{ trait_impl.trait_ty|type_name(ci) }}
+    {%- endfor -%}
+    , IDisposable {
     protected ulong pointer;
     private int _wasDestroyed = 0;
     private long _callCounter = 1;


### PR DESCRIPTION
Include UniFFI object trait implementations in the generated class inheritance list.

The generator previously ignored `Object::trait_impls()`, causing concrete objects to expose the trait methods without formally implementing the corresponding C# interfaces.

Generate every interface reported by `trait_impls()` alongside the object's main interface and `IDisposable`.